### PR TITLE
Add debug print and cmake config

### DIFF
--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -1,0 +1,55 @@
+#[[
+********************************************************************************
+Root Level CMake Configuration for Libraries
+********************************************************************************
+
+This CMakeLists.txt manages all libraries in the project. It establishes build 
+order and handles interdependencies between libraries.
+
+--------------------------------------------------------------------------------
+Adding a New Library:
+--------------------------------------------------------------------------------
+1. Create your library directory structure:
+   libs/
+   └── your_library/
+       ├── CMakeLists.txt
+       ├── Inc/
+       └── Src/
+
+2. Create your library's CMakeLists.txt:
+example: 
+   cmake_minimum_required(VERSION 3.22)
+   project(your_library)
+   
+   add_library(your_library STATIC
+       ${CMAKE_CURRENT_SOURCE_DIR}/Src/your_source.c
+   )
+   
+   target_include_directories(your_library PUBLIC
+       ${CMAKE_CURRENT_SOURCE_DIR}/Inc
+   )
+   
+   # If your library needs common utilities:
+   target_link_libraries(your_library PUBLIC
+       common   # Link your library against the common library if needed
+       stm32cubemx  # STM32 HAL is needed
+   )
+
+3. Add your library to this file using add_subdirectory()
+
+--------------------------------------------------------------------------------
+Dependencies:
+--------------------------------------------------------------------------------
+- The 'common' library should be built first as it provides shared utilities
+- Libraries that depend on 'common' should list it in their target_link_libraries()
+- Build order is determined by add_subdirectory() order in this file
+********************************************************************************
+]]
+
+cmake_minimum_required(VERSION 3.22)
+
+# Add the common, gps, and sensors subdirectories
+add_subdirectory(common)
+add_subdirectory(gps)
+add_subdirectory(sensors)
+# Add more subdirectories here as needed

--- a/libs/common/CMakeLists.txt
+++ b/libs/common/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.22)
+project(common)
+
+add_library(common INTERFACE)
+
+target_include_directories(common INTERFACE
+    ${CMAKE_CURRENT_SOURCE_DIR}/Inc
+)

--- a/libs/common/Inc/logger.h
+++ b/libs/common/Inc/logger.h
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * @file: logging.h
+ * @brief: Simple debug printing utility for STM32 projects
+ *
+ * @note: Requires UART to be initialized before use
+ *
+ * @todo: This utility is very basic and could be expanded to include more features
+ ******************************************************************************/
+
+#pragma once
+
+#include "main.h"
+#include <string.h>
+#include <stdio.h> // Required for snprintf()
+
+#ifdef DEBUG
+#define DEBUG_UART huart2
+
+// Formatted debug print over UART
+#define debug_print(fmt, ...)                                                                                  \
+  do                                                                                                           \
+  {                                                                                                            \
+    char buffer[128]; /* Adjust size as needed */                                                              \
+    int error_check = snprintf(buffer, sizeof(buffer), fmt, ##__VA_ARGS__);                                    \
+    if (error_check < 0)                                                                                       \
+    {                                                                                                          \
+      /* Handle error */                                                                                       \
+      HAL_UART_Transmit(&DEBUG_UART, (uint8_t *)"snprintf error\n", 15, 100);                                  \
+    }                                                                                                          \
+    else                                                                                                       \
+    {                                                                                                          \
+      /* Cast to size_t for the comparison to sizeof result below */                                           \
+    size_t len = (size_t)error_check;                                                                          \
+    buffer[sizeof(buffer) - 1] = '\0'; /* Explicit null termination */                                         \
+    HAL_UART_Transmit(&DEBUG_UART, (uint8_t *)buffer, len > sizeof(buffer) ? sizeof(buffer) - 1 : len, 100);   \
+    }                                                                                                          \
+  } while (0)
+#else
+#define debug_print(fmt, ...) // Empty definition if DEBUG is not enabled
+#endif

--- a/libs/sensors/CMakeLists.txt
+++ b/libs/sensors/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.22)
+project(sensors)
+
+add_library(sensors STATIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/Src/bme688.c
+)
+
+target_include_directories(sensors PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/Inc  # sensor specific headers
+)
+
+target_link_libraries(sensors PUBLIC
+    common  # Inherit common's includes
+)

--- a/libs/sensors/Inc/bme688.h
+++ b/libs/sensors/Inc/bme688.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void sensors_placholder_function(void);

--- a/libs/sensors/Src/bme688.c
+++ b/libs/sensors/Src/bme688.c
@@ -1,0 +1,7 @@
+#include "bme688.h"
+
+void sensors_placholder_function(void)
+{
+  // This ensures the sensors library compiles
+  int y = 2 + 1;
+}

--- a/tests/test_bme688/CMakeLists.txt
+++ b/tests/test_bme688/CMakeLists.txt
@@ -51,11 +51,13 @@ target_sources(${CMAKE_PROJECT_NAME} PRIVATE
 target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE
     # Add user defined include paths here
     # Example: ${CMAKE_SOURCE_DIR}/../../Src/Sensors/Inc
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../libs/sensors/Inc
 )
 
 # Add project symbols (macros)
 target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE
     # Add user defined symbols for local scope to target executable
+    # Note: CubeMX adds DEBUG for the Debug build type
 )
 
 # Add STM32CubeMX generated sources
@@ -64,6 +66,17 @@ add_subdirectory(
     ${CMAKE_BINARY_DIR}/stm32cubemx       # Binary directory
 )
 
+add_subdirectory(
+    ${CMAKE_SOURCE_DIR}/../../libs/common
+    ${CMAKE_BINARY_DIR}/libs/common
+)
+
+add_subdirectory(
+    ${CMAKE_SOURCE_DIR}/../../libs/sensors
+    ${CMAKE_BINARY_DIR}/libs/sensors
+)
+
 target_link_libraries(${CMAKE_PROJECT_NAME} 
+    sensors
     stm32cubemx
 )

--- a/tests/test_bme688/test_bme688.c
+++ b/tests/test_bme688/test_bme688.c
@@ -20,6 +20,7 @@
 #include "main.h"
 #include "usart.h"
 #include "gpio.h"
+#include "logger.h"
 
 /* Private includes ----------------------------------------------------------*/
 /* USER CODE BEGIN Includes */


### PR DESCRIPTION
Cobbling together a debug print utility, largely from Reece's commit here: 7b16b8b10925547d7d57b7251b25285920b7ffc9 Plus the addition of handling variables in the print macro.

Haven't been able to test this yet, as there seems to be something not quite right with the cmake config. Going to keep at it, but if you have a chance to take a look and notice anything incorrect @reecewayt feel free to comment!

**Edit**: Ready for review, usage example is below.