### PR TITLE
Gps lib

### DIFF
--- a/Config/Inc/target_config.h
+++ b/Config/Inc/target_config.h
@@ -1,4 +1,4 @@
-#pragma
+#pragma once
 
 /*******************************************************************************
  * @brief: Target MCU Configuration
@@ -13,7 +13,7 @@
  ******************************************************************************/
 
 #ifndef TARGET_MCU
-#error "TARGET_MCU must be defined"
+    #error "TARGET_MCU must be defined"
 #endif
 
 /* STM32L4 Series Configuration */

--- a/docs/drivers/max-m10s.md
+++ b/docs/drivers/max-m10s.md
@@ -1,9 +1,167 @@
-# Guide for using the max-m10s driver and api
+# u-blox MAX-M10S GNSS Driver API
 
-## Getting started
-The first thing to do is to make sure you have the stm32 CubeMX tool setup with the proper pin configurations. This library is currently only implemented using the I2C bus. Configure your pins as follows:
-1. Select PB7 and PB6 as the SDA and SCL respectively. Note that these pins correspond to A5 (SCL), and A4 (SDA) of the nucleo-l432kc. TODO: Add directions for portability to other nucleo boards as well. Refer to datasheet for other boards.
-2. Got to connectivity, then click I2C1. 
-3. Under parameter settings set I2C speed mode to fast mode (400 KHz).
-4. Under GPIO settings set SCL and SDA ot Pull-up type.
+## Overview
+This is a lightweight driver that provides a C interface for communicating with the [u-blox MAX-M10S](https://www.u-blox.com/en/product/max-m10-series?legacy=Current#Documentation-&-resources) GNSS module over I2C. It supports configuration of the gps module to output UBX messages, NAV status checking for polling the device, and position data retrieval using the UBX protocol.
+
+The driver is designed for use with STM32 microcontrollers and **depends on the HAL I2C driver for communication.**
+
+**Note**: Communication with the device is realtively slow and requires a 1 second delay between reading and writing to the device. I was not 
+able to find information in the datasheet that specified this for I2C communication but I arrived at 1 second through trial and error. Anyhting less then 1 second tended to cause errors and the Ublox module would not respond with a valid message. Because of this you will see `HAL_Delay(1000)` in the driver code's method for sending a ubx command.
+
+## Key Features
+- I2C communication with the MAX-M10S module
+- UBX protocol support
+- Navigation status checking
+- Position, Velocity, and Time (PVT) data retrieval
+- Module configuration and reset capabilities
+
+## Getting Started
+1. Initialize the module using `ublox_init()`
+2. Check for valid GPS fix using `ublox_get_nav_status()`
+3. Once a fix is obtained, retrieve position data using `ublox_get_pvt()` followed by `ublox_get_curr_position()`
+
+## Example Usage
+```c
+int32_t lat, lon, height;
+
+// Initialize the module
+if (ublox_init() != UBLOX_OK) {
+    // Handle error
+}
+
+// Wait for valid fix
+while (ublox_get_nav_status() != UBLOX_OK) {
+    HAL_Delay(1000);  // Check every second
+}
+
+// Get position data
+if (ublox_get_pvt() == UBLOX_OK) {
+    if (ublox_get_curr_position(&lat, &lon, &height) == UBLOX_OK) {
+        // Process position data
+        // Note: lat/lon are in degrees * 10^-7
+        // height is in millimeters
+    }
+}
+```
+
+## Function Documentation
+
+### `ublox_init()`
+Initializes the u-blox GNSS module.
+
+This function performs the following initialization steps:
+1. Initializes the I2C peripheral
+2. Configures the module for UBX protocol output
+3. Disables NMEA protocol output
+
+**Returns:**
+- `UBLOX_OK` if initialization successful, error code otherwise
+
+### `ublox_get_nav_status()`
+Retrieves navigation status from the GNSS module.
+
+Requests and processes the UBX-NAV-STATUS message to determine if:
+- GPS has a valid fix
+- Time data is valid
+
+**Returns:**
+- `UBLOX_OK` if valid fix and time data available, error code otherwise
+
+### `ublox_get_pvt()`
+Requests Position, Velocity, and Time data from the module.
+
+Sends a UBX-NAV-PVT message request to the module. This function must be called before `ublox_get_curr_position()` to get fresh position data.
+
+**Returns:**
+- `UBLOX_OK` if valid PVT data received, error code otherwise
+
+### `ublox_get_curr_position()`
+Retrieves the current position from the most recent PVT data.
+
+**Note:** This function must be called after a successful `ublox_get_pvt()` call
+
+**Parameters:**
+- `lat`: Pointer to store latitude (degrees * 10^-7)
+- `lon`: Pointer to store longitude (degrees * 10^-7)
+- `height`: Pointer to store height above mean sea level (millimeters)
+
+**Returns:**
+- `UBLOX_OK` if valid position data retrieved, error code otherwise
+
+**Example coordinate conversion:**
+- Latitude: 455137510 * 10^-7 = 45.5137510° N
+- Longitude: -1226464697 * 10^-7 = -122.6464697° W
+- Height: 36673 mm = 36.673 meters
+
+### `ublox_reset()`
+Resets the u-blox GNSS module.
+
+Performs a hardware reset of the module and clears all configuration data in RAM and battery-backed RAM.
+
+**Returns:**
+- `UBLOX_OK` if reset successful, error code otherwise
+
+## Status Codes
+```c
+typedef enum {
+    UBLOX_OK = 0,                    // Operation completed successfully
+    UBLOX_ERROR = 1,                 // Generic error
+    UBLOX_TIMEOUT = 2,               // Operation timed out
+    UBLOX_INVALID_DATA = 3,          // Received invalid or corrupted data
+    UBLOX_NOT_INITIALIZED = 4,        // Module not initialized
+    UBLOX_CHECKSUM_ERROR = 5,        // Message checksum verification failed
+    UBLOX_PACKET_VALIDITY_ERROR = 6,  // Packet validation failed
+    UBLOX_PACKET_NEEDS_PROCESSING = 7, // Previous packet not yet processed
+    UBLOX_NACK_ERROR = 8,            // Received NACK from module
+} ublox_status_e;
+```
+
+## Test Application
+The driver includes a test application that demonstrates proper usage of this API.
+The test application provides these commands:
+
+- `I`: Initialize the GPS module
+- `F`: Check GPS Fix status
+- `L`: Get Location data (lat/lon/height)
+
+The test application shows proper initialization sequence, error handling, and data retrieval methods. It also demonstrates how to convert the raw position values into human-readable format.
+
+See `u-blox_test.c` for the complete test application implementation.
+
+**Compiling and building the test application**
+```bash
+cd tests/test_gps
+cmake --preset Debug # If using cmake presets and vscode extension
+cmake --build build/Debug/
+```
+**Flashing the target board**   
+I'm using the nucleo-l432kc board but this application could easily be extended to other boards with the proper 
+linking of the stm32 HAL for your target board
+
+You can flash the board using STM32CubeProgrammer CLI directly, or automate this step using VS Code Tasks. I've provided the tasks.json configuration below. 
+```json
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "type": "shell",
+            "label": "Flash Test GPS",
+            "command": "STM32_Programmer_CLI",
+            "args": [
+                "--connect",
+                "port=swd",
+                "--download",
+                "${workspaceFolder}/tests/test_gps/build/Debug/test_gps.elf",
+                "-hardRst",
+                "-rst",
+                "--start"
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "problemMatcher": []
+        }
+    ]
+}
+```
 

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -1,0 +1,54 @@
+#[[
+********************************************************************************
+Root Level CMake Configuration for Libraries
+********************************************************************************
+
+This CMakeLists.txt manages all libraries in the project. It establishes build 
+order and handles interdependencies between libraries.
+
+--------------------------------------------------------------------------------
+Adding a New Library:
+--------------------------------------------------------------------------------
+1. Create your library directory structure:
+   libs/
+   └── your_library/
+       ├── CMakeLists.txt
+       ├── Inc/
+       └── Src/
+
+2. Create your library's CMakeLists.txt:
+example: 
+   cmake_minimum_required(VERSION 3.22)
+   project(your_library)
+   
+   add_library(your_library STATIC
+       ${CMAKE_CURRENT_SOURCE_DIR}/Src/your_source.c
+   )
+   
+   target_include_directories(your_library PUBLIC
+       ${CMAKE_CURRENT_SOURCE_DIR}/Inc
+   )
+   
+   # If your library needs common utilities:
+   target_link_libraries(your_library PUBLIC
+       common   # Link your library against the common library if needed
+       stm32cubemx  # STM32 HAL is needed
+   )
+
+3. Add your library to this file using add_subdirectory()
+
+--------------------------------------------------------------------------------
+Dependencies:
+--------------------------------------------------------------------------------
+- The 'common' library should be built first as it provides shared utilities
+- Libraries that depend on 'common' should list it in their target_link_libraries()
+- Build order is determined by add_subdirectory() order in this file
+********************************************************************************
+]]
+
+cmake_minimum_required(VERSION 3.22)
+
+# Add the common and gps subdirectories
+add_subdirectory(common)
+add_subdirectory(gps)
+# Add more subdirectories here as needed

--- a/libs/common/CMakeLists.txt
+++ b/libs/common/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.22)
+project(common)
+
+add_library(common INTERFACE)
+
+target_include_directories(common INTERFACE
+    ${CMAKE_CURRENT_SOURCE_DIR}/Inc
+)

--- a/libs/common/Inc/logging.h
+++ b/libs/common/Inc/logging.h
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * @file: logging.h
+ * @brief: Simple debug printing utility for STM32 projects
+ * 
+ * @note: Requires UART to be initialized before use
+ * 
+ * @todo: This utility is very basic and could be expanded to include more features
+ ******************************************************************************/
+
+#pragma once
+
+#include "main.h"
+#include <string.h>
+
+#ifdef DEBUG
+    #define DEBUG_UART huart2
+    #define debug_print(msg) do { \
+        HAL_UART_Transmit(&DEBUG_UART, (uint8_t*)(msg), strlen(msg), 100); \
+    } while(0)
+#else
+    #define debug_print(msg)
+#endif

--- a/libs/gps/CMakeLists.txt
+++ b/libs/gps/CMakeLists.txt
@@ -1,11 +1,10 @@
-# TODO: Implement library CMake file
+# Library: ublox_gps_driver
 cmake_minimum_required(VERSION 3.22)
 project(ublox_gps_driver)
 
 add_library(ublox_gps_driver STATIC
     ${CMAKE_CURRENT_SOURCE_DIR}/Src/u-blox_gnss_MAX-M10S.c
 )
-
 
 target_compile_definitions(ublox_gps_driver PUBLIC
     STM32L432xx
@@ -19,5 +18,6 @@ target_include_directories(ublox_gps_driver PUBLIC
 
 # Link against the stm32cubemx INTERFACE Library
 target_link_libraries(ublox_gps_driver PUBLIC
+    common
     stm32cubemx
 )

--- a/libs/gps/CMakeLists.txt
+++ b/libs/gps/CMakeLists.txt
@@ -1,1 +1,23 @@
 # TODO: Implement library CMake file
+cmake_minimum_required(VERSION 3.22)
+project(ublox_gps_driver)
+
+add_library(ublox_gps_driver STATIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/Src/u-blox_gnss_MAX-M10S.c
+)
+
+
+target_compile_definitions(ublox_gps_driver PUBLIC
+    STM32L432xx
+    $<$<CONFIG:Debug>:DEBUG>
+)
+
+target_include_directories(ublox_gps_driver PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/Inc
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../Config/Inc
+)
+
+# Link against the stm32cubemx INTERFACE Library
+target_link_libraries(ublox_gps_driver PUBLIC
+    stm32cubemx
+)

--- a/libs/gps/Inc/u-blox_Class_and_ID.h
+++ b/libs/gps/Inc/u-blox_Class_and_ID.h
@@ -1,31 +1,8 @@
 /*******************************************************************************
- * @file: ubx_protocol.h
- * @brief: U-blox (UBX) protocol frame structure and message definitions for MAX-M10
- * 
- * Frame Structure (see page 41 of interface manual):
- * +-------+-------+-------+-----+--------+---------+-------+-------+
- * | SYNC1 | SYNC2 | CLASS | ID  | LENGTH | PAYLOAD | CK_A  | CK_B  |
- * | 0xB5  | 0x62  |  1B   | 1B  |   2B   |   NB    |  1B   |  1B   |
- * +-------+-------+-------+-----+--------+---------+-------+-------+
- * 
- * Total frame size  6 + N + 2 bytes (where N is payload length)
- * Checksum is calculated over the range: CLASS to PAYLOAD (inclusive)
- * 
- * @note: The u-blox module support two types of standards NMEA and UBX. NMEA is not implement in this library but could 
- *       be implemented in the future.
- * 
- * @version: 1.0
- * @sources:
- *   - u-blox MAX-M10 Interface Manual v5.10 (page of this manual will be referenced in comments)
- *     https://www.u-blox.com/en/product/max-m10-series#Documentation-&-resources
- *   - SparkFun u-blox GNSS Arduino Library v3
- *     https://github.com/sparkfun/SparkFun_u-blox_GNSS_v3
- * 
+ * @file: u-blox_Class_and_ID.h
  * @author: Reece Wayt
  * @date: January 13, 2025
  ******************************************************************************/
-
-
 #pragma once
 
 /*******************************************************************************
@@ -54,12 +31,15 @@
 /*******************************************************************************
  * Message IDs
 ********************************************************************************/
-
 // Class: NAV
 #define UBX_NAV_STATUS 0x03    // Receiver Navigation Status
-
+#define UBX_NAV_PVT 0x07       // Navigation Position Velocity Time Solution
 
 // Class: CFG
-#define UBX_CFG_VALSET_PKT_LEN 7 // (Version + Layers + Reserved + Bit Key Value) => 7 Bytes
 #define UBX_CFG_VALSET 0x8A     // Set configuration item values
+#define UBX_CFG_RST 0x04        // Reset Receiver / Clear Backup Data Structures
+
+// Class: ACK
+#define UBX_ACK_ACK 0x01        // Acknowledge
+#define UBX_ACK_NACK 0x00       // Not Acknowledge
 

--- a/libs/gps/Inc/u-blox_Class_and_ID.h
+++ b/libs/gps/Inc/u-blox_Class_and_ID.h
@@ -8,7 +8,7 @@
  * | 0xB5  | 0x62  |  1B   | 1B  |   2B   |   NB    |  1B   |  1B   |
  * +-------+-------+-------+-----+--------+---------+-------+-------+
  * 
- * Total frame size = 6 + N + 2 bytes (where N is payload length)
+ * Total frame size  6 + N + 2 bytes (where N is payload length)
  * Checksum is calculated over the range: CLASS to PAYLOAD (inclusive)
  * 
  * @note: The u-blox module support two types of standards NMEA and UBX. NMEA is not implement in this library but could 
@@ -28,317 +28,38 @@
 
 #pragma once
 
-#include "target_config.h"
-
-const uint8_t UBX_SYNCH_1 = 0xB5;
-const uint8_t UBX_SYNCH_2 = 0x62;
-
 /*******************************************************************************
  * Class Message Types
 ********************************************************************************/
 //UBX Message Class. See Chapter 3
-const uint8_t UBX_CLASS_NAV = 0x01;  // Navigation Results Messages: Position, Speed, Time, Acceleration, Heading, DOP, SVs used
-const uint8_t UBX_CLASS_RXM = 0x02;  // Receiver Manager Messages: Satellite Status, RTC Status
-const uint8_t UBX_CLASS_INF = 0x04;  // Information Messages: Printf-Style Messages, with IDs such as Error, Warning, Notice
-const uint8_t UBX_CLASS_ACK = 0x05;  // Ack/Nak Messages: Acknowledge or Reject messages to UBX-CFG input messages
-const uint8_t UBX_CLASS_CFG = 0x06;  // Configuration Input Messages: Configure the receiver.
-const uint8_t UBX_CLASS_UPD = 0x09;  // Firmware Update Messages: Memory/Flash erase/write, Reboot, Flash identification, etc.
-const uint8_t UBX_CLASS_MON = 0x0A;  // Monitoring Messages: Communication Status, CPU Load, Stack Usage, Task Status
-const uint8_t UBX_CLASS_AID = 0x0B;  //(NEO-M8P ONLY!!!) AssistNow Aiding Messages: Ephemeris, Almanac, other A-GPS data input
-const uint8_t UBX_CLASS_TIM = 0x0D;  // Timing Messages: Time Pulse Output, Time Mark Results
-const uint8_t UBX_CLASS_ESF = 0x10;  //(NEO-M8P ONLY!!!) External Sensor Fusion Messages: External Sensor Measurements and Status Information
-const uint8_t UBX_CLASS_MGA = 0x13;  // Multiple GNSS Assistance Messages: Assistance data for various GNSS
-const uint8_t UBX_CLASS_LOG = 0x21;  // Logging Messages: Log creation, deletion, info and retrieval
-const uint8_t UBX_CLASS_SEC = 0x27;  // Security Feature Messages
-const uint8_t UBX_CLASS_HNR = 0x28;  //(NEO-M8P ONLY!!!) High Rate Navigation Results Messages: High rate time, position speed, heading
+#define UBX_CLASS_NAV 0x01  // Navigation Results Messages: Position, Speed, Time, Acceleration, Heading, DOP, SVs used
+#define UBX_CLASS_RXM 0x02  // Receiver Manager Messages: Satellite Status, RTC Status
+#define UBX_CLASS_INF 0x04  // Information Messages: Printf-Style Messages, with IDs such as Error, Warning, Notice
+#define UBX_CLASS_ACK 0x05  // Ack/Nak Messages: Acknowledge or Reject messages to UBX-CFG input messages
+#define UBX_CLASS_CFG 0x06  // Configuration Input Messages: Configure the receiver.
+#define UBX_CLASS_UPD 0x09  // Firmware Update Messages: Memory/Flash erase/write, Reboot, Flash identification, etc.
+#define UBX_CLASS_MON 0x0A  // Monitoring Messages: Communication Status, CPU Load, Stack Usage, Task Status
+#define UBX_CLASS_AID 0x0B  //(NEO-M8P ONLY!!!) AssistNow Aiding Messages: Ephemeris, Almanac, other A-GPS data input
+#define UBX_CLASS_TIM 0x0D  // Timing Messages: Time Pulse Output, Time Mark Results
+#define UBX_CLASS_ESF 0x10  //(NEO-M8P ONLY!!!) External Sensor Fusion Messages: External Sensor Measurements and Status Information
+#define UBX_CLASS_MGA 0x13  // Multiple GNSS Assistance Messages: Assistance data for various GNSS
+#define UBX_CLASS_LOG 0x21  // Logging Messages: Log creation, deletion, info and retrieval
+#define UBX_CLASS_SEC 0x27  // Security Feature Messages
+#define UBX_CLASS_HNR 0x28  //(NEO-M8P ONLY!!!) High Rate Navigation Results Messages: High rate time, position speed, heading
 //@TODO: NMEA messages are not implemented in this library
-const uint8_t UBX_CLASS_NMEA = 0xF0; // NMEA Strings: standard NMEA strings
-const uint8_t UBX_CLASS_PUBX = 0xF1; // Proprietary NMEA-format messages defined by u-blox
+#define UBX_CLASS_NMEA 0xF0 // NMEA Strings: standard NMEA strings
+#define UBX_CLASS_PUBX 0xF1 // Proprietary NMEA-format messages defined by u-blox
 
 
 /*******************************************************************************
  * Message IDs
 ********************************************************************************/
 
-// Class: CFG
-// The following are used for configuration.
-const uint8_t UBX_CFG_ANT = 0x13;       // Antenna Control Settings. Used to configure the antenna control settings
-const uint8_t UBX_CFG_BATCH = 0x93;     // Get/set data batching configuration.
-const uint8_t UBX_CFG_CFG = 0x09;       // Clear, Save, and Load Configurations. Used to save current configuration
-const uint8_t UBX_CFG_DAT = 0x06;       // Set User-defined Datum or The currently defined Datum
-const uint8_t UBX_CFG_DGNSS = 0x70;     // DGNSS configuration
-const uint8_t UBX_CFG_ESFALG = 0x56;    // ESF alignment
-const uint8_t UBX_CFG_ESFA = 0x4C;      // ESF accelerometer
-const uint8_t UBX_CFG_ESFG = 0x4D;      // ESF gyro
-const uint8_t UBX_CFG_GEOFENCE = 0x69;  // Geofencing configuration. Used to configure a geofence
-const uint8_t UBX_CFG_GNSS = 0x3E;      // GNSS system configuration
-const uint8_t UBX_CFG_HNR = 0x5C;       // High Navigation Rate
-const uint8_t UBX_CFG_INF = 0x02;       // Depending on packet length, either: poll configuration for one protocol, or information message configuration
-const uint8_t UBX_CFG_ITFM = 0x39;      // Jamming/Interference Monitor configuration
-const uint8_t UBX_CFG_LOGFILTER = 0x47; // Data Logger Configuration
-const uint8_t UBX_CFG_MSG = 0x01;       // Poll a message configuration, or Set Message Rate(s), or Set Message Rate
-const uint8_t UBX_CFG_NAV5 = 0x24;      // Navigation Engine Settings. Used to configure the navigation engine including the dynamic model.
-const uint8_t UBX_CFG_NAVX5 = 0x23;     // Navigation Engine Expert Settings
-const uint8_t UBX_CFG_NMEA = 0x17;      // Extended NMEA protocol configuration V1
-const uint8_t UBX_CFG_ODO = 0x1E;       // Odometer, Low-speed COG Engine Settings
-const uint8_t UBX_CFG_PM2 = 0x3B;       // Extended power management configuration
-const uint8_t UBX_CFG_PMS = 0x86;       // Power mode setup
-const uint8_t UBX_CFG_PRT = 0x00;       // Used to configure port specifics. Polls the configuration for one I/O Port, or Port configuration for UART ports, or Port configuration for USB port, or Port configuration for SPI port, or Port configuration for DDC port
-const uint8_t UBX_CFG_PWR = 0x57;       // Put receiver in a defined power state
-const uint8_t UBX_CFG_RATE = 0x08;      // Navigation/Measurement Rate Settings. Used to set port baud rates.
-const uint8_t UBX_CFG_RINV = 0x34;      // Contents of Remote Inventory
-const uint8_t UBX_CFG_RST = 0x04;       // Reset Receiver / Clear Backup Data Structures. Used to reset device.
-const uint8_t UBX_CFG_RXM = 0x11;       // RXM configuration
-const uint8_t UBX_CFG_SBAS = 0x16;      // SBAS configuration
-const uint8_t UBX_CFG_TMODE3 = 0x71;    // Time Mode Settings 3. Used to enable Survey In Mode
-const uint8_t UBX_CFG_TP5 = 0x31;       // Time Pulse Parameters
-const uint8_t UBX_CFG_USB = 0x1B;       // USB Configuration
-const uint8_t UBX_CFG_VALDEL = 0x8C;    // Used for config of higher version u-blox modules (ie protocol v27 and above). Deletes values corresponding to provided keys/ provided keys with a transaction
-const uint8_t UBX_CFG_VALGET = 0x8B;    // Used for config of higher version u-blox modules (ie protocol v27 and above). Configuration Items
-const uint8_t UBX_CFG_VALSET = 0x8A;    // Used for config of higher version u-blox modules (ie protocol v27 and above). Sets values corresponding to provided key-value pairs/ provided key-value pairs within a transaction.
-
-
-// Class: PUBX
-// The following are used to enable PUBX messages with configureMessage
-// See the M8 receiver description & protocol specification for more details
-const uint8_t UBX_PUBX_CONFIG = 0x41;   // Set protocols and baud rate
-const uint8_t UBX_PUBX_POSITION = 0x00; // Lat/Long position data
-const uint8_t UBX_PUBX_RATE = 0x40;     // Set/get NMEA message output rate
-const uint8_t UBX_PUBX_SVSTATUS = 0x03; // Satellite status
-const uint8_t UBX_PUBX_TIME = 0x04;     // Time of day and clock information
-
-// Class: HNR
-// The following are used to configure the HNR message rates
-const uint8_t UBX_HNR_ATT = 0x01; // HNR Attitude
-const uint8_t UBX_HNR_INS = 0x02; // HNR Vehicle Dynamics
-const uint8_t UBX_HNR_PVT = 0x00; // HNR PVT
-
-// Class: INF
-// The following are used to configure INF UBX messages (information messages).  Descriptions from UBX messages overview (ZED_F9P Interface Description Document page 34)
-const uint8_t UBX_INF_CLASS = 0x04;   // All INF messages have 0x04 as the class
-const uint8_t UBX_INF_DEBUG = 0x04;   // ASCII output with debug contents
-const uint8_t UBX_INF_ERROR = 0x00;   // ASCII output with error contents
-const uint8_t UBX_INF_NOTICE = 0x02;  // ASCII output with informational contents
-const uint8_t UBX_INF_TEST = 0x03;    // ASCII output with test contents
-const uint8_t UBX_INF_WARNING = 0x01; // ASCII output with warning contents
-
-// Class: LOG
-// The following are used to configure LOG UBX messages (loggings messages).  Descriptions from UBX messages overview (ZED_F9P Interface Description Document page 34)
-const uint8_t UBX_LOG_CREATE = 0x07;           // Create Log File
-const uint8_t UBX_LOG_ERASE = 0x03;            // Erase Logged Data
-const uint8_t UBX_LOG_FINDTIME = 0x0E;         // Find index of a log entry based on a given time, or response to FINDTIME requested
-const uint8_t UBX_LOG_INFO = 0x08;             // Poll for log information, or Log information
-const uint8_t UBX_LOG_RETRIEVEPOSEXTRA = 0x0F; // Odometer log entry
-const uint8_t UBX_LOG_RETRIEVEPOS = 0x0B;      // Position fix log entry
-const uint8_t UBX_LOG_RETRIEVESTRING = 0x0D;   // Byte string log entry
-const uint8_t UBX_LOG_RETRIEVE = 0x09;         // Request log data
-const uint8_t UBX_LOG_STRING = 0x04;           // Store arbitrary string on on-board flash
-
-// Class: MGA
-// The following are used to configure MGA UBX messages (Multiple GNSS Assistance Messages).  Descriptions from UBX messages overview (ZED_F9P Interface Description Document page 34)
-const uint8_t UBX_MGA_ACK_DATA0 = 0x60;      // Multiple GNSS Acknowledge message
-const uint8_t UBX_MGA_ANO = 0x20;            // Multiple GNSS AssistNow Offline assistance - NOT SUPPORTED BY THE ZED-F9P! "The ZED-F9P supports AssistNow Online only."
-const uint8_t UBX_MGA_BDS_EPH = 0x03;        // BDS Ephemeris Assistance
-const uint8_t UBX_MGA_BDS_ALM = 0x03;        // BDS Almanac Assistance
-const uint8_t UBX_MGA_BDS_HEALTH = 0x03;     // BDS Health Assistance
-const uint8_t UBX_MGA_BDS_UTC = 0x03;        // BDS UTC Assistance
-const uint8_t UBX_MGA_BDS_IONO = 0x03;       // BDS Ionospheric Assistance
-const uint8_t UBX_MGA_DBD = 0x80;            // Either: Poll the Navigation Database, or Navigation Database Dump Entry
-const uint8_t UBX_MGA_GAL_EPH = 0x02;        // Galileo Ephemeris Assistance
-const uint8_t UBX_MGA_GAL_ALM = 0x02;        // Galileo Almanac Assitance
-const uint8_t UBX_MGA_GAL_TIMOFFSET = 0x02;  // Galileo GPS time offset assistance
-const uint8_t UBX_MGA_GAL_UTC = 0x02;        // Galileo UTC Assistance
-const uint8_t UBX_MGA_GLO_EPH = 0x06;        // GLONASS Ephemeris Assistance
-const uint8_t UBX_MGA_GLO_ALM = 0x06;        // GLONASS Almanac Assistance
-const uint8_t UBX_MGA_GLO_TIMEOFFSET = 0x06; // GLONASS Auxiliary Time Offset Assistance
-const uint8_t UBX_MGA_GPS_EPH = 0x00;        // GPS Ephemeris Assistance
-const uint8_t UBX_MGA_GPS_ALM = 0x00;        // GPS Almanac Assistance
-const uint8_t UBX_MGA_GPS_HEALTH = 0x00;     // GPS Health Assistance
-const uint8_t UBX_MGA_GPS_UTC = 0x00;        // GPS UTC Assistance
-const uint8_t UBX_MGA_GPS_IONO = 0x00;       // GPS Ionosphere Assistance
-const uint8_t UBX_MGA_INI_POS_XYZ = 0x40;    // Initial Position Assistance
-const uint8_t UBX_MGA_INI_POS_LLH = 0x40;    // Initial Position Assitance
-const uint8_t UBX_MGA_INI_TIME_UTC = 0x40;   // Initial Time Assistance
-const uint8_t UBX_MGA_INI_TIME_GNSS = 0x40;  // Initial Time Assistance
-const uint8_t UBX_MGA_INI_CLKD = 0x40;       // Initial Clock Drift Assitance
-const uint8_t UBX_MGA_INI_FREQ = 0x40;       // Initial Frequency Assistance
-const uint8_t UBX_MGA_INI_EOP = 0x40;        // Earth Orientation Parameters Assistance
-const uint8_t UBX_MGA_QZSS_EPH = 0x05;       // QZSS Ephemeris Assistance
-const uint8_t UBX_MGA_QZSS_ALM = 0x05;       // QZSS Almanac Assistance
-const uint8_t UBX_MGA_QZAA_HEALTH = 0x05;    // QZSS Health Assistance
-
-// Class: MON
-// The following are used to configure the MON UBX messages (monitoring messages). Descriptions from UBX messages overview (ZED_F9P Interface Description Document page 35)
-const uint8_t UBX_MON_COMMS = 0x36; // Comm port information
-const uint8_t UBX_MON_GNSS = 0x28;  // Information message major GNSS selection
-const uint8_t UBX_MON_HW2 = 0x0B;   // Extended Hardware Status
-const uint8_t UBX_MON_HW3 = 0x37;   // HW I/O pin information
-const uint8_t UBX_MON_HW = 0x09;    // Hardware Status
-const uint8_t UBX_MON_IO = 0x02;    // I/O Subsystem Status
-const uint8_t UBX_MON_MSGPP = 0x06; // Message Parse and Process Status
-const uint8_t UBX_MON_PATCH = 0x27; // Output information about installed patches
-const uint8_t UBX_MON_PMP = 0x35;   // PMP monitoring data
-const uint8_t UBX_MON_PT2 = 0x2B;   // Multi-GNSS production test monitor
-const uint8_t UBX_MON_RF = 0x38;    // RF information
-const uint8_t UBX_MON_RXBUF = 0x07; // Receiver Buffer Status
-const uint8_t UBX_MON_RXR = 0x21;   // Receiver Status Information
-const uint8_t UBX_MON_SPAN = 0x31;  // Signal characteristics
-const uint8_t UBX_MON_SYS = 0x39;   // Current system performance information
-const uint8_t UBX_MON_TEMP = 0x0E;  // Temperature value and state
-const uint8_t UBX_MON_TXBUF = 0x08; // Transmitter Buffer Status. Used for query tx buffer size/state.
-const uint8_t UBX_MON_VER = 0x04;   // Receiver/Software Version. Used for obtaining Protocol Version.
-
 // Class: NAV
-// The following are used to configure the NAV UBX messages (navigation results messages). Descriptions from UBX messages overview (ZED_F9P Interface Description Document page 35-36)
-const uint8_t UBX_NAV_ATT = 0x05;       // Vehicle "Attitude" Solution
-const uint8_t UBX_NAV_CLOCK = 0x22;     // Clock Solution
-const uint8_t UBX_NAV_COV = 0x36;       // Covariance matrices
-const uint8_t UBX_NAV_DOP = 0x04;       // Dilution of precision
-const uint8_t UBX_NAV_EELL = 0x3D;      // Position error ellipse parameters
-const uint8_t UBX_NAV_EOE = 0x61;       // End of Epoch
-const uint8_t UBX_NAV_GEOFENCE = 0x39;  // Geofencing status. Used to poll the geofence status
-const uint8_t UBX_NAV_HPPOSECEF = 0x13; // High Precision Position Solution in ECEF. Used to find our positional accuracy (high precision).
-const uint8_t UBX_NAV_HPPOSLLH = 0x14;  // High Precision Geodetic Position Solution. Used for obtaining lat/long/alt in high precision
-const uint8_t UBX_NAV_ODO = 0x09;       // Odometer Solution
-const uint8_t UBX_NAV_ORB = 0x34;       // GNSS Orbit Database Info
-const uint8_t UBX_NAV_PL = 0x62;        // Protection Level Information
-const uint8_t UBX_NAV_POSECEF = 0x01;   // Position Solution in ECEF
-const uint8_t UBX_NAV_POSLLH = 0x02;    // Geodetic Position Solution
-const uint8_t UBX_NAV_PVT = 0x07;       // All the things! Position, velocity, time, PDOP, height, h/v accuracies, number of satellites. Navigation Position Velocity Time Solution.
-const uint8_t UBX_NAV_PVAT = 0x17;      // Navigation position velocity attitude time solution (ZED-F9R only)
-const uint8_t UBX_NAV_RELPOSNED = 0x3C; // Relative Positioning Information in NED frame
-const uint8_t UBX_NAV_RESETODO = 0x10;  // Reset odometer
-const uint8_t UBX_NAV_SAT = 0x35;       // Satellite Information
-const uint8_t UBX_NAV_SBAS = 0x32;      // SBAS subsystem
-const uint8_t UBX_NAV_SLAS = 0x42;      // QZSS L1S SLAS status data
-const uint8_t UBX_NAV_SIG = 0x43;       // Signal Information
-const uint8_t UBX_NAV_STATUS = 0x03;    // Receiver Navigation Status
-const uint8_t UBX_NAV_SVIN = 0x3B;      // Survey-in data. Used for checking Survey In status
-const uint8_t UBX_NAV_TIMEBDS = 0x24;   // BDS Time Solution
-const uint8_t UBX_NAV_TIMEGAL = 0x25;   // Galileo Time Solution
-const uint8_t UBX_NAV_TIMEGLO = 0x23;   // GLO Time Solution
-const uint8_t UBX_NAV_TIMEGPS = 0x20;   // GPS Time Solution
-const uint8_t UBX_NAV_TIMELS = 0x26;    // Leap second event information
-const uint8_t UBX_NAV_TIMENAVIC = 0x63; // NavIC time solution
-const uint8_t UBX_NAV_TIMEUTC = 0x21;   // UTC Time Solution
-const uint8_t UBX_NAV_VELECEF = 0x11;   // Velocity Solution in ECEF
-const uint8_t UBX_NAV_VELNED = 0x12;    // Velocity Solution in NED
-const uint8_t UBX_NAV_AOPSTATUS = 0x60; // AssistNow Autonomous status
+#define UBX_NAV_STATUS 0x03    // Receiver Navigation Status
 
-// Class: RXM
-// The following are used to configure the RXM UBX messages (receiver manager messages). Descriptions from UBX messages overview (ZED_F9P Interface Description Document page 36)
-const uint8_t UBX_RXM_COR = 0x34;       // Differential correction input status
-const uint8_t UBX_RXM_MEASX = 0x14;     // Satellite Measurements for RRLP
-const uint8_t UBX_RXM_PMP = 0x72;       // PMP raw data (NEO-D9S) (two different versions) (packet size for version 0x01 is variable)
-const uint8_t UBX_RXM_QZSSL6 = 0x73;    // QZSSL6 data (NEO-D9C)
-const uint8_t UBX_RXM_PMREQ = 0x41;     // Requests a Power Management task (two different packet sizes)
-const uint8_t UBX_RXM_RAWX = 0x15;      // Multi-GNSS Raw Measurement Data
-const uint8_t UBX_RXM_RLM = 0x59;       // Galileo SAR Short-RLM report (two different packet sizes)
-const uint8_t UBX_RXM_RTCM = 0x32;      // RTCM input status
-const uint8_t UBX_RXM_SFRBX = 0x13;     // Broadcast Navigation Data Subframe
-const uint8_t UBX_RXM_SPARTN = 0x33;    // SPARTN input status
-const uint8_t UBX_RXM_SPARTNKEY = 0x36; // Poll/transfer dynamic SPARTN keys
 
-// Class: SEC
-// The following are used to configure the SEC UBX messages (security feature messages). Descriptions from UBX messages overview (ZED_F9P Interface Description Document page 36)
-const uint8_t UBX_SEC_UNIQID = 0x03; // Unique chip ID
-
-// Class: TIM
-// The following are used to configure the TIM UBX messages (timing messages). Descriptions from UBX messages overview (ZED_F9P Interface Description Document page 36)
-const uint8_t UBX_TIM_TM2 = 0x03;  // Time mark data
-const uint8_t UBX_TIM_TP = 0x01;   // Time Pulse Timedata
-const uint8_t UBX_TIM_VRFY = 0x06; // Sourced Time Verification
-
-// Class: UPD
-// The following are used to configure the UPD UBX messages (firmware update messages). Descriptions from UBX messages overview (ZED-F9P Interface Description Document page 36)
-const uint8_t UBX_UPD_SOS = 0x14; // Poll Backup Fil Restore Status, Create Backup File in Flash, Clear Backup File in Flash, Backup File Creation Acknowledge, System Restored from Backup
-
-// The following are used to enable RTCM messages
-const uint8_t UBX_RTCM_MSB = 0xF5;    // All RTCM enable commands have 0xF5 as MSB
-const uint8_t UBX_RTCM_1005 = 0x05;   // Stationary RTK reference ARP
-const uint8_t UBX_RTCM_1074 = 0x4A;   // GPS MSM4
-const uint8_t UBX_RTCM_1077 = 0x4D;   // GPS MSM7
-const uint8_t UBX_RTCM_1084 = 0x54;   // GLONASS MSM4
-const uint8_t UBX_RTCM_1087 = 0x57;   // GLONASS MSM7
-const uint8_t UBX_RTCM_1094 = 0x5E;   // Galileo MSM4
-const uint8_t UBX_RTCM_1097 = 0x61;   // Galileo MSM7
-const uint8_t UBX_RTCM_1124 = 0x7C;   // BeiDou MSM4
-const uint8_t UBX_RTCM_1127 = 0x7F;   // BeiDou MSM7
-const uint8_t UBX_RTCM_1230 = 0xE6;   // GLONASS code-phase biases, set to once every 10 seconds
-const uint8_t UBX_RTCM_4072_0 = 0xFE; // Reference station PVT (ublox proprietary RTCM message)
-const uint8_t UBX_RTCM_4072_1 = 0xFD; // Additional reference station information (ublox proprietary RTCM message)
-
-// Class: ACK
-const uint8_t UBX_ACK_NACK = 0x00;
-const uint8_t UBX_ACK_ACK = 0x01;
-const uint8_t UBX_ACK_NONE = 0x02; // Not a real value
-
-// Class: ESF
-//  The following constants are used to get External Sensor Measurements and Status
-//  Information.
-const uint8_t UBX_ESF_MEAS = 0x02;
-const uint8_t UBX_ESF_RAW = 0x03;
-const uint8_t UBX_ESF_STATUS = 0x10;
-const uint8_t UBX_ESF_RESETALG = 0x13;
-const uint8_t UBX_ESF_ALG = 0x14;
-const uint8_t UBX_ESF_INS = 0x15; // 36 bytes
-
-// CFG-TMODE: Time mode configuration
-const uint8_t SVIN_MODE_DISABLE = 0x00;
-const uint8_t SVIN_MODE_ENABLE = 0x01; // Survey-In
-const uint8_t SVIN_MODE_FIXED = 0x02;
-
-// The following consts are used to configure the various ports and streams for those ports. See -CFG-PRT.
-const uint8_t COM_PORT_I2C = 0;
-const uint8_t COM_PORT_UART1 = 1;
-const uint8_t COM_PORT_UART2 = 2;
-const uint8_t COM_PORT_USB = 3;
-const uint8_t COM_PORT_SPI = 4;
-
-// Port IDs used by MON-COMMS
-// UBX-18010802 - R15 also documents 0x0101 and 0x0200 - both are "Reserved"
-const uint16_t COM_PORT_ID_I2C = 0x0000; // Port IDs used by MON-COMMS
-const uint16_t COM_PORT_ID_UART1 = 0x0100;
-const uint16_t COM_PORT_ID_UART2 = 0x0201;
-const uint16_t COM_PORT_ID_USB = 0x0300;
-const uint16_t COM_PORT_ID_SPI = 0x0400;
-
-const uint8_t COM_TYPE_UBX = (1 << 0);
-const uint8_t COM_TYPE_NMEA = (1 << 1);
-const uint8_t COM_TYPE_RTCM3 = (1 << 5);
-const uint8_t COM_TYPE_SPARTN = (1 << 6);
-
-// Odometer configuration - flags
-const uint8_t UBX_CFG_ODO_USE_ODO = (1 << 0);
-const uint8_t UBX_CFG_ODO_USE_COG = (1 << 1);
-const uint8_t UBX_CFG_ODO_OUT_LP_VEL = (1 << 2);
-const uint8_t UBX_CFG_ODO_OUT_LP_COG = (1 << 3);
-
-// Odometer configuration - odoCfg
-enum odoCfg_e
-{
-  UBX_CFG_ODO_RUN = 0,
-  UBX_CFG_ODO_CYCLE,
-  UBX_CFG_ODO_SWIM,
-  UBX_CFG_ODO_CAR,
-  UBX_CFG_ODO_CUSTOM,
-};
-
-// Configuration Sub-Section mask definitions for saveConfigSelective (UBX-CFG-CFG)
-const uint32_t VAL_CFG_SUBSEC_IOPORT = 0x00000001;   // ioPort - communications port settings (causes IO system reset!)
-const uint32_t VAL_CFG_SUBSEC_MSGCONF = 0x00000002;  // msgConf - message configuration
-const uint32_t VAL_CFG_SUBSEC_INFMSG = 0x00000004;   // infMsg - INF message configuration
-const uint32_t VAL_CFG_SUBSEC_NAVCONF = 0x00000008;  // navConf - navigation configuration
-const uint32_t VAL_CFG_SUBSEC_RXMCONF = 0x00000010;  // rxmConf - receiver manager configuration
-const uint32_t VAL_CFG_SUBSEC_SENCONF = 0x00000100;  // senConf - sensor interface configuration (requires protocol 19+)
-const uint32_t VAL_CFG_SUBSEC_RINVCONF = 0x00000200; // rinvConf - remove inventory configuration
-const uint32_t VAL_CFG_SUBSEC_ANTCONF = 0x00000400;  // antConf - antenna configuration
-const uint32_t VAL_CFG_SUBSEC_LOGCONF = 0x00000800;  // logConf - logging configuration
-const uint32_t VAL_CFG_SUBSEC_FTSCONF = 0x00001000;  // ftsConf - FTS configuration (FTS products only)
-
-// Bitfield wakeupSources for UBX_RXM_PMREQ
-const uint32_t VAL_RXM_PMREQ_WAKEUPSOURCE_UARTRX = 0x00000008;  // uartrx
-const uint32_t VAL_RXM_PMREQ_WAKEUPSOURCE_EXTINT0 = 0x00000020; // extint0
-const uint32_t VAL_RXM_PMREQ_WAKEUPSOURCE_EXTINT1 = 0x00000040; // extint1
-const uint32_t VAL_RXM_PMREQ_WAKEUPSOURCE_SPICS = 0x00000080;   // spics
+// Class: CFG
+#define UBX_CFG_VALSET_PKT_LEN 7 // (Version + Layers + Reserved + Bit Key Value) => 7 Bytes
+#define UBX_CFG_VALSET 0x8A     // Set configuration item values
 

--- a/libs/gps/Inc/u-blox_gnss_MAX-M10S.h
+++ b/libs/gps/Inc/u-blox_gnss_MAX-M10S.h
@@ -1,28 +1,158 @@
+/*
+File u-blox_gnss_MAX-M10S.h
+*/
 #pragma once
 
 #include "target_config.h"
 #include "u-blox_Class_and_ID.h"
+#include "main.h"
+#include "i2c.h"
+#include <string.h>
+#include <stdbool.h>
 
-// UBX Protocol Constants
+/*
+General UBX Frame Description
+*/
 #define UBX_SYNC_CHAR_1 0xB5
 #define UBX_SYNC_CHAR_2 0x62
-#define UBX_HEADER_LENGTH 6  // 2 sync + 1 class + 1 id + 2 length
+#define UBX_HEADER_LENGTH 6  // 2 sync + 1 class + 1 id + 2 length (bytes)
 #define UBX_CHECKSUM_LENGTH 2
-#define UBX_MAX_PAYLOAD_LENGTH 128  // Reduced for STM32L4KC RAM constraints
+#define UBX_MAX_PAYLOAD_LENGTH 256  // Maximum payload length for u-blox (see pg. 24 of Integration Manual)
 #define UBX_MAX_PACKET_LENGTH (UBX_HEADER_LENGTH + UBX_MAX_PAYLOAD_LENGTH + UBX_CHECKSUM_LENGTH)
 
-// I2C Configuration for u-blox
-#define UBLOX_I2C_ADDR 0x42  // Default u-blox I2C address
-#define I2C_TIMEOUT 100      // Timeout in milliseconds
+/* 
+Config Keys, each key consist of 32-bits
+See pg 124 of Interface Description
+We want to configure the UBX to be in BBR so it will retain this setting while battery backup supply is on. 
+*/
+#define UBX_CFG_L 0x01001000
+#define UBLOX_CFG_UBX_OUTPUT 0x10720001
 
+// I2C Configuration for u-blox
 //use left shift as bit stuffing for I2C address tack on 0 for write and 1 for read
-const uint8_t ublox_i2c_addr = 0x42 << 1; // u-blox i2c address
+#define UBLOX_I2C_ADDR 0x42 << 1  // Default u-blox I2C address
+#define I2C_TIMEOUT 100      // Timeout in milliseconds
 
 // Static buffer for payload data
 static uint8_t ubx_payload_buffer[UBX_MAX_PAYLOAD_LENGTH];
 static uint8_t ubx_packet_buffer[UBX_MAX_PACKET_LENGTH];
 
+typedef enum {
+  UBX = 0, 
+  NMEA = 1  //Not implemented
+} comm_type_t;
+
+// Union packet for holding current frame validity data
+typedef struct{
+    union {
+        uint8_t all;
+        struct {
+            uint8_t check_sum_a : 1;    // Checksum A is valid if set
+            uint8_t check_sum_b : 1;    // Checksum B is valid if set
+            uint8_t class : 1;          // Class matches reqested class, valid if set
+            uint8_t id : 1;             // ID matches requested ID, valid if set
+            uint8_t packet : 1;         // Packet is valid if set, all other bits must be valid
+        } bits;
+    };
+} valid_packet_t;
 
 
+// This struct will hold the ubx frame data, it is a bidirectional packet used for sending and receiving
+typedef struct {
+  uint8_t cls;
+  uint8_t id;
+  uint16_t len;             // Length of the payload. Does not include cls, id, or checksum bytes
+  uint16_t counter;         // Keeps track of number of overall bytes received. Some responses are larger than 255 bytes.
+  uint16_t startingSpot;    // The counter value needed to go past before we begin recording into payload array
+  uint8_t *payload;         // We will allocate RAM for the payload if/when needed.
+  uint8_t checksumA;        // Given to us from module. Checked against the rolling calculated A/B checksums.
+  uint8_t checksumB;  
+  valid_packet_t valid;     // Valid bits for a current frame
+} ubx_packet_t;
+
+
+#define UBX_NAV_STATUS_LEN 16 
+
+typedef struct
+{
+  uint32_t iTOW;  // GPS time of week of the navigation epoch: ms
+  uint8_t gpsFix; // GPSfix Type: 0x00 = no fix; 0x01 = dead reckoning only; 0x02 = 2D-fix; 0x03 = 3D-fix
+                  // 0x04 = GPS + dead reckoning combined; 0x05 = Time only fix; 0x06..0xff = reserved
+  union
+  {
+    uint8_t all;
+    struct
+    {
+      uint8_t gpsFixOk : 1; // 1 = position and velocity valid and within DOP and ACC Masks.
+      uint8_t diffSoln : 1; // 1 = differential corrections were applied
+      uint8_t wknSet : 1;   // 1 = Week Number valid (see Time Validity section for details)
+      uint8_t towSet : 1;   // 1 = Time of Week valid (see Time Validity section for details)
+    } bits;
+  } flags;
+  union
+  {
+    uint8_t all;
+    struct
+    {
+      uint8_t diffCorr : 1;      // 1 = differential corrections available
+      uint8_t carrSolnValid : 1; // 1 = valid carrSoln
+      uint8_t reserved : 4;
+      uint8_t mapMatching : 2; // map matching status: 00: none
+                               // 01: valid but not used, i.e. map matching data was received, but was too old
+                               // 10: valid and used, map matching data was applied
+                               // 11: valid and used, map matching data was applied.
+    } bits;
+  } fixStat;
+  union
+  {
+    uint8_t all;
+    struct
+    {
+      uint8_t psmState : 2; // power save mode state
+                            // 0: ACQUISITION [or when psm disabled]
+                            // 1: TRACKING
+                            // 2: POWER OPTIMIZED TRACKING
+                            // 3: INACTIVE
+      uint8_t reserved1 : 1;
+      uint8_t spoofDetState : 2; // Spoofing detection state
+                                 // 0: Unknown or deactivated
+                                 // 1: No spoofing indicated
+                                 // 2: Spoofing indicated
+                                 // 3: Multiple spoofing indications
+      uint8_t reserved2 : 1;
+      uint8_t carrSoln : 2; // Carrier phase range solution status:
+                            // 0: no carrier phase range solution
+                            // 1: carrier phase range solution with floating ambiguities
+                            // 2: carrier phase range solution with fixed ambiguities
+    } bits;
+  } flags2;
+  uint32_t ttff; // Time to first fix (millisecond time tag): ms
+  uint32_t msss; // Milliseconds since Startup / Reset: ms
+} UBX_NAV_STATUS_data_t;
+
+// FIXME: Calling function should use this structure for reading
+//static UBX_NAV_STATUS_data_t packetUBX_NAV_STATUS; // Ram will be allocated when needed
+static ubx_packet_t ubx_packet;
+
+typedef enum {
+    UBLOX_OK = 0,
+    UBLOX_ERROR = 1,
+    UBLOX_TIMEOUT = 2,
+    UBLOX_INVALID_DATA = 3,
+    UBLOX_NOT_INITIALIZED = 4,
+    UBLOX_CHECKSUM_ERROR = 5,
+    UBLOX_PACKET_VALIDITY_ERROR = 6,
+    UBLOX_PACKET_NEEDS_PROCESSING = 7
+    //TODO: Add more error codes as needed
+} UBLOX_Status_t; 
+
+
+
+// Function prototypes
+UBLOX_Status_t ublox_init(void);
+UBLOX_Status_t ublox_get_nav_status(void);
+//static UBLOX_Status_t ublox_send_command(ubx_packet_t *outgoing_ubx, bool expect_ack_only); // TODO: Add parameters
+//static void calc_check_sum(ubx_packet_t *outgoing_ubx);
+//static uint16_t set_i2c_transaction_size(uint16_t len);
 
 

--- a/libs/gps/Inc/u-blox_gnss_MAX-M10S.h
+++ b/libs/gps/Inc/u-blox_gnss_MAX-M10S.h
@@ -1,26 +1,26 @@
 /*******************************************************************************
  * @file: u-blox_gnss_MAX-M10s.h
  * @brief: U-blox (UBX) protocol frame structure and message definitions for MAX-M10
- * 
+ *
  * Frame Structure (see page 41 of interface manual):
  * +-------+-------+-------+-----+--------+---------+-------+-------+
  * | SYNC1 | SYNC2 | CLASS | ID  | LENGTH | PAYLOAD | CK_A  | CK_B  |
  * | 0xB5  | 0x62  |  1B   | 1B  |   2B   |   NB    |  1B   |  1B   |
  * +-------+-------+-------+-----+--------+---------+-------+-------+
- * 
+ *
  * Total frame size  6 + N + 2 bytes (where N is payload length)
  * Checksum is calculated over the range: CLASS to PAYLOAD (inclusive)
- * 
- * @note:The u-blox module supports two types of standards NMEA and UBX. NMEA is not implement in this library but could 
+ *
+ * @note:The u-blox module supports two types of standards NMEA and UBX. NMEA is not implement in this library but could
  *       be implemented in the future.
- * 
+ *
  * @version: 1.0
  * @sources:
  *   - u-blox MAX-M10 Interface Manual v5.10 (page of this manual will be referenced in comments)
  *     https://www.u-blox.com/en/product/max-m10-series#Documentation-&-resources
  *   - SparkFun u-blox GNSS Arduino Library v3
  *     https://github.com/sparkfun/SparkFun_u-blox_GNSS_v3
- * 
+ *
  * @author: Reece Wayt
  * @date: January 13, 2025
  ******************************************************************************/
@@ -29,7 +29,7 @@
 #include "target_config.h"
 #include "u-blox_Class_and_ID.h"
 #include "u-blox_packet_types.h"
-#ifdef DEBUG 
+#ifdef DEBUG
   #include "logging.h"
 #endif
 #include "main.h"
@@ -79,7 +79,7 @@ typedef enum {
 
 /**
  * @brief Error and status codes for u-blox module
- * 
+ *
  */
 typedef enum {
     UBLOX_OK = 0,                       // Operation completed successfully
@@ -91,12 +91,12 @@ typedef enum {
     UBLOX_PACKET_VALIDITY_ERROR = 6,    // Packet validation failed
     UBLOX_PACKET_NEEDS_PROCESSING = 7,  // Previous packet not yet processed
     UBLOX_NACK_ERROR = 8,               // Received NACK from module
-} ublox_status_e; 
+} ublox_status_e;
 
 /**
  * @brief Union of all possible UBX message payloads
- * @note This union allows for easy extensibility to add more payload types as needed. 
- *       If updating payload types, add a new structure in u-blox_packet_types.h then 
+ * @note This union allows for easy extensibility to add more payload types as needed.
+ *       If updating payload types, add a new structure in u-blox_packet_types.h then
  *       add it to the union here.
  */
 typedef union {
@@ -111,7 +111,7 @@ typedef union {
 /**
  * @brief UBX packet structure, which included some additional fields for tracking packet data and validity
  *        of the frame.
- * 
+ *
  * @note Careful management of this structure is important, as it is static and shared across the module.
  */
 typedef struct {
@@ -122,11 +122,11 @@ typedef struct {
   uint16_t counter;            // Keeps track of number of overall bytes received. Some responses are larger than 256 bytes.
   uint16_t startingSpot;       // The counter value needed to go past before we begin recording into payload array
   ubx_payload_t payload;       // Union of all payload types
-  uint8_t checksumA;        
-  uint8_t checksumB;  
+  uint8_t checksumA;
+  uint8_t checksumB;
   bool valid;                  // Valid bits for a current frame, needs to be cleared after each frame is processed
 } ubx_packet_t;
- 
+
 
 /*******************************************************************************
  * Global Variables
@@ -150,23 +150,17 @@ ublox_status_e ublox_get_nav_status(void);
 
 /**
  * @brief Sends message to ublox module to get position, velocity, and time (PVT) data from the GNSS module
- * @todo Implemnt this function
  */
 ublox_status_e ublox_get_pvt(void);
 
 /**
- * @brief Read the most recent pvt data 
- * @todo Implement this function
+ * @brief Read the most recent pvt data
  */
 ublox_status_e ublox_get_curr_position(int32_t *lat, int32_t *lon, int32_t *height);
 
 /**
- * @brief Resets the u-blox GNSS module which will clear all configurations and data structures in RAM 
+ * @brief Resets the u-blox GNSS module which will clear all configurations and data structures in RAM
  *        and BBR memory. Hence, resets everything to default settings.
  * @return ublox_status_e Reset status
  */
 ublox_status_e ublox_reset(void);
-
-
-
-

--- a/libs/gps/Inc/u-blox_packet_types.h
+++ b/libs/gps/Inc/u-blox_packet_types.h
@@ -1,0 +1,209 @@
+/*******************************************************************************
+ * @file: u-blox_packet_types.h
+ * @brief: Packet type definitions for u-blox MAX-M10S GNSS module
+ * 
+ * This file contains the structure definitions for different UBX protocol message
+ * payloads. Each structure maps to a specific message type and contains the 
+ * appropriate fields as defined in the u-blox interface manual.
+ * 
+ * @important: The last declaration of this file is a union that allows for easy
+ *            access to different types of payload structues using the same memory. 
+ * 
+ * @author: Reece Wayt
+ * @date: January 25, 2025
+ ******************************************************************************/
+
+#pragma once
+
+#include <stdint.h>
+
+
+/*******************************************************************************
+ * UBX-NAV-STATUS Packet Type
+ ******************************************************************************/
+/**
+ * @brief UBX-NAV-STATUS payload structure
+ * @note See pg. 105-107 of Interface Description
+ */
+
+typedef struct
+{
+  uint32_t iTOW;  // GPS time of week of the navigation epoch: ms
+  uint8_t gpsFix; // GPSfix Type: 0x00 = no fix; 0x01 = dead reckoning only; 0x02 = 2D-fix; 0x03 = 3D-fix
+                  // 0x04 = GPS + dead reckoning combined; 0x05 = Time only fix; 0x06..0xff = reserved
+  union
+  {
+    uint8_t all;
+    struct
+    {
+      uint8_t gpsFixOk : 1; // 1 = position and velocity valid and within DOP and ACC Masks.
+      uint8_t diffSoln : 1; // 1 = differential corrections were applied
+      uint8_t wknSet : 1;   // 1 = Week Number valid (see Time Validity section for details)
+      uint8_t towSet : 1;   // 1 = Time of Week valid (see Time Validity section for details)
+    } bits;
+  } flags;
+  union
+  {
+    uint8_t all;
+    struct
+    {
+      uint8_t diffCorr : 1;      // 1 = differential corrections available
+      uint8_t carrSolnValid : 1; // 1 = valid carrSoln
+      uint8_t reserved : 4;
+      uint8_t mapMatching : 2; // map matching status: 00: none
+                               // 01: valid but not used, i.e. map matching data was received, but was too old
+                               // 10: valid and used, map matching data was applied
+                               // 11: valid and used, map matching data was applied.
+    } bits;
+  } fixStat;
+  union
+  {
+    uint8_t all;
+    struct
+    {
+      uint8_t psmState : 2; // power save mode state
+                            // 0: ACQUISITION [or when psm disabled]
+                            // 1: TRACKING
+                            // 2: POWER OPTIMIZED TRACKING
+                            // 3: INACTIVE
+      uint8_t reserved1 : 1;
+      uint8_t spoofDetState : 2; // Spoofing detection state
+                                 // 0: Unknown or deactivated
+                                 // 1: No spoofing indicated
+                                 // 2: Spoofing indicated
+                                 // 3: Multiple spoofing indications
+      uint8_t reserved2 : 1;
+      uint8_t carrSoln : 2; // Carrier phase range solution status:
+                            // 0: no carrier phase range solution
+                            // 1: carrier phase range solution with floating ambiguities
+                            // 2: carrier phase range solution with fixed ambiguities
+    } bits;
+  } flags2;
+  uint32_t ttff; // Time to first fix (millisecond time tag): ms
+  uint32_t msss; // Milliseconds since Startup / Reset: ms
+} ubx_nav_status_s;
+
+/*******************************************************************************
+ * UBX-NAV-PVT Packet Type
+ * 
+ * @desciption: This packet type is used to store the data from the UBX-NAV-PVT
+ *             message which provides position, velocity, and time information.
+ ******************************************************************************/
+typedef struct
+{
+  uint32_t iTOW; // GPS time of week of the navigation epoch: ms
+  uint16_t year; // Year (UTC)
+  uint8_t month; // Month, range 1..12 (UTC)
+  uint8_t day;   // Day of month, range 1..31 (UTC)
+  uint8_t hour;  // Hour of day, range 0..23 (UTC)
+  uint8_t min;   // Minute of hour, range 0..59 (UTC)
+  uint8_t sec;   // Seconds of minute, range 0..60 (UTC)
+  union
+  {
+    uint8_t all;
+    struct
+    {
+      uint8_t validDate : 1;     // 1 = valid UTC Date
+      uint8_t validTime : 1;     // 1 = valid UTC time of day
+      uint8_t fullyResolved : 1; // 1 = UTC time of day has been fully resolved (no seconds uncertainty).
+      uint8_t validMag : 1;      // 1 = valid magnetic declination
+    } bits;
+  } valid;
+  uint32_t tAcc;   // Time accuracy estimate (UTC): ns
+  int32_t nano;    // Fraction of second, range -1e9 .. 1e9 (UTC): ns
+  uint8_t fixType; // GNSSfix Type:
+                   // 0: no fix
+                   // 1: dead reckoning only
+                   // 2: 2D-fix
+                   // 3: 3D-fix
+                   // 4: GNSS + dead reckoning combined
+                   // 5: time only fix
+  union
+  {
+    uint8_t all;
+    struct
+    {
+      uint8_t gnssFixOK : 1; // 1 = valid fix (i.e within DOP & accuracy masks)
+      uint8_t diffSoln : 1;  // 1 = differential corrections were applied
+      uint8_t psmState : 3;
+      uint8_t headVehValid : 1; // 1 = heading of vehicle is valid, only set if the receiver is in sensor fusion mode
+      uint8_t carrSoln : 2;     // Carrier phase range solution status:
+                                // 0: no carrier phase range solution
+                                // 1: carrier phase range solution with floating ambiguities
+                                // 2: carrier phase range solution with fixed ambiguities
+    } bits;
+  } flags;
+  union
+  {
+    uint8_t all;
+    struct
+    {
+      uint8_t reserved : 5;
+      uint8_t confirmedAvai : 1; // 1 = information about UTC Date and Time of Day validity confirmation is available
+      uint8_t confirmedDate : 1; // 1 = UTC Date validity could be confirmed
+      uint8_t confirmedTime : 1; // 1 = UTC Time of Day could be confirmed
+    } bits;
+  } flags2;
+  uint8_t numSV;    // Number of satellites used in Nav Solution
+  int32_t lon;      // Longitude: deg * 1e-7
+  int32_t lat;      // Latitude: deg * 1e-7
+  int32_t height;   // Height above ellipsoid: mm
+  int32_t hMSL;     // Height above mean sea level: mm
+  uint32_t hAcc;    // Horizontal accuracy estimate: mm
+  uint32_t vAcc;    // Vertical accuracy estimate: mm
+  int32_t velN;     // NED north velocity: mm/s
+  int32_t velE;     // NED east velocity: mm/s
+  int32_t velD;     // NED down velocity: mm/s
+  int32_t gSpeed;   // Ground Speed (2-D): mm/s
+  int32_t headMot;  // Heading of motion (2-D): deg * 1e-5
+  uint32_t sAcc;    // Speed accuracy estimate: mm/s
+  uint32_t headAcc; // Heading accuracy estimate (both motion and vehicle): deg * 1e-5
+  uint16_t pDOP;    // Position DOP * 0.01
+  union
+  {
+    uint16_t all;
+    struct
+    {
+      uint16_t invalidLlh : 1;        // 1 = Invalid lon, lat, height and hMSL
+      uint16_t lastCorrectionAge : 4; // Age of the most recently received differential correction:
+                                     // 0: Not available
+                                     // 1: Age between 0 and 1 second
+                                     // 2: Age between 1 (inclusive) and 2 seconds
+                                     // 3: Age between 2 (inclusive) and 5 seconds
+                                     // 4: Age between 5 (inclusive) and 10 seconds
+                                     // 5: Age between 10 (inclusive) and 15 seconds
+                                     // 6: Age between 15 (inclusive) and 20 seconds
+                                     // 7: Age between 20 (inclusive) and 30 seconds
+                                     // 8: Age between 30 (inclusive) and 45 seconds
+                                     // 9: Age between 45 (inclusive) and 60 seconds
+                                     // 10: Age between 60 (inclusive) and 90 seconds
+                                     // 11: Age between 90 (inclusive) and 120 seconds
+                                     // >=12: Age greater or equal than 120 seconds
+      uint16_t reserved : 8;
+      uint16_t authTime : 1;     // Flag that indicates if the output time has been validated
+                                 // against an external trusted time source
+      uint16_t nmaFixStatus : 1; // Flag assigned to a fix that has been computed
+                                 // mixing satellites with data authenticated through
+                                 // Navigation Message Authentication (NMA) methods
+                                 // and satellites using unauthenticated data.
+    } bits;
+  } flags3;
+  uint8_t reserved0[4];
+  int32_t headVeh; // Heading of vehicle (2-D): deg * 1e-5
+  int16_t magDec;  // Magnetic declination: deg * 1e-2
+  uint16_t magAcc; // Magnetic declination accuracy: deg * 1e-2
+} ubx_nav_pvt_s;
+
+
+/*******************************************************************************
+ * @brief UBX-ACK-ACK & UBX-ACK_NACK payload structure
+ * @note: The payload structure is the same for both ACK and NACK messages
+ *          The only difference is that the ID will be 0x01 for ACK and 0x00 for NACK
+ *          See pg. 49 of Interface Description
+ ********************************************************************************/
+typedef struct
+{
+  uint8_t clsID; // This is an echo message of the Class and ID of the original config message
+  uint8_t msgID;  
+} ubx_ack_ack_s;
+

--- a/libs/gps/Src/u-blox_gnss_MAX-M10S.c
+++ b/libs/gps/Src/u-blox_gnss_MAX-M10S.c
@@ -1,245 +1,548 @@
-/*
-File u-blox_gnss_MAX-M10S.c
-*/
+/*******************************************************************************
+ * @file: u-blox_gnss_MAX-M10S.c
+ * @brief: Implementation of the u-blox MAX-M10S GNSS module driver using UBX protocol
+ *         Provides initialization and communication functions for configuring and
+ *         retrieving data from the GPS module over I2C.
+ * 
+ * @note: This implementation focuses on UBX protocol support and I2C communication.
+ *        NMEA protocol support may be added in future versions.
+ * 
+ * @author: Reece Wayt
+ * @date: January 13, 2025
+ * @version: 1.0
+ * 
+ * @dependencies:
+ *   - STM32 HAL I2C driver
+ *   - STM32 HAL UART driver (for debug output)
+ ******************************************************************************/
 
 #include "u-blox_gnss_MAX-M10S.h"
 
-// Private function headers
-static UBLOX_Status_t ublox_send_command(ubx_packet_t *outgoing_ubx, bool expect_ack_only);
-static void calc_check_sum(ubx_packet_t *outgoing_ubx);
-static uint16_t set_transaction_size(uint16_t len);
-static UBLOX_Status_t ublox_set_i2c_output(comm_type_t comm_settings);
 
-// Private initialization flag might need to fix this
+/*******************************************************************************
+ * Private Function Prototypes
+ ******************************************************************************/
+static ublox_status_e ublox_send_command(bool expect_ack_only);
+static void calc_check_sum(void);
+static uint16_t set_transaction_size(uint16_t len);
+static ublox_status_e set_ubx_i2c_output(ublox_comm_type_e comm_settings);
+static ublox_status_e parse_ack_response(void);
+static ublox_status_e process_nav_status(void);
+static ublox_status_e validate_nav_pvt(void); 
+
+/*******************************************************************************
+ * Private & Extern Variables
+ ******************************************************************************/
 static bool ublox_initialized = false;
+static ubx_packet_t ubx_packet;
 extern UART_HandleTypeDef huart2;
 
-#ifdef DEBUG 
-    const uint8_t ublox_error_init[] = "u-blox GNSS Module not initialized. Call ublox_init() first.\r\n";
-    const uint8_t ublox_error_memset[] = "Memory allocation failed. Check if memory is available.\r\n";
-    const uint8_t ublox_error_i2c[] = "I2C peripheral not initialized. Check I2C configuration.\r\n";
-    const uint8_t ublox_packet_error[] = "u-blox packet error. Check packet validity.\r\n";
-    const uint8_t ublox_transmits_msg[] = "Requesting data from u-blox.\r\n";
-    const uint8_t ublox_transaction_size_overflow[] = "Transaction size overflow. Check packet length.\r\n";
-#endif
+/*******************************************************************************
+ * Public Function Implementations
+ ******************************************************************************/
 
-UBLOX_Status_t ublox_init(void){
+/**
+ * @brief Initializes the u-blox GNSS module
+ * @details Initializes I2C communication, clears packet structure, and configures
+ *          module for UBX protocol output.
+ * @return ublox_status_e Initialization status
+ */
+
+ublox_status_e ublox_init(void){
     // Initialize the I2C peripheral
+    ublox_comm_type_e comm_settings = UBX;
     MX_I2C1_Init();
     // Zero packet structure
     memset(&ubx_packet, 0, sizeof(ubx_packet_t));
-    ublox_initialized = true;
-
-    UBLOX_Status_t status = ublox_set_i2c_output(UBX);
-    if(status != UBLOX_OK)
+    ublox_status_e status = set_ubx_i2c_output(comm_settings);
+    if(status != UBLOX_OK) {
         return status; 
-        
+    }
+    ublox_initialized = true;
     return UBLOX_OK;
 }
 
+/**
+ * @brief Retrieves navigation status from the GNSS module
+ * @details Requests NAV-STATUS message which provides receiver navigation status
+ *          including fix type, validity flags, and time information
+ * @return Returns UBLOX_OK if fix is valid and time is valid; else UBLOX_ERROR_XX
+ */
+ublox_status_e ublox_get_nav_status(void){
+    bool ack_only = false; // Expect full response
 
-// Based on sparkfun's getNAVSTATUS(uint16_t maxWait = kUBLOXGNSSDefaultMaxWait); func
-UBLOX_Status_t ublox_get_nav_status(void){
-    // Check if the module has been initialized
-    bool ack_only = false;
     if(!ublox_initialized){
         #ifdef DEBUG
-            HAL_UART_Transmit(&huart2, ublox_error_init, sizeof(ublox_error_init), 10);
+            debug_print("GPS module not initialized!\r\n");
         #endif
         return UBLOX_NOT_INITIALIZED;
     }
-    if(ubx_packet.valid.bits.packet){
+
+    if(ubx_packet.valid){
         #ifdef DEBUG
-            HAL_UART_Transmit(&huart2, ublox_packet_error, sizeof(ublox_packet_error), 10);
+            debug_print("Packet is valid, previous frame not processed correctly\r\n");
         #endif
         return UBLOX_PACKET_NEEDS_PROCESSING;
     }
-    memset(&ubx_packet, 0, sizeof(ubx_packet_t)); // Clear the packet before sending a new request
+    // Always clear the packet before sending a new request
+    memset(&ubx_packet, 0, UBX_PACKET_LENGTH); 
+
+    // Setup packet for nav status request
     ubx_packet.cls = UBX_CLASS_NAV;
     ubx_packet.id = UBX_NAV_STATUS;
 
-    UBLOX_Status_t status = ublox_send_command(&ubx_packet, ack_only);
-    return status;
-}
-
-
-// Private function
-static UBLOX_Status_t ublox_send_command(ubx_packet_t *outgoing_ubx, bool expect_ack_only){
-    //TODO: Implement this function
-    calc_check_sum(outgoing_ubx);
-
     #ifdef DEBUG
-        HAL_UART_Transmit(&huart2, ublox_transmits_msg, sizeof(ublox_transmits_msg), 10);
-    #endif   
-    //uint16_t bytes_left_to_send = outgoing_ubx->len;
-    //uint16_t start_spot = 0; 
-    
-    //to set transaction size
-    uint16_t size = set_transaction_size(outgoing_ubx->len);
-    if (size == 0){ // Should never be zero 
+        debug_print("Requesting NAV-STATUS...\r\n");
+    #endif
+
+    if(ublox_send_command(ack_only) != UBLOX_OK){
+        #ifdef DEBUG
+            debug_print("Error sending NAV-STATUS request\r\n");
+        #endif
         return UBLOX_ERROR;
     }
+
+    // Command sent now read the response
+    uint16_t size = UBX_HEADER_LENGTH + UBX_NAV_STATUS_LEN + UBX_CHECKSUM_LENGTH;
+    uint8_t buff[size];
+
+    if(HAL_I2C_Master_Receive(&hi2c1, UBLOX_I2C_ADDR, buff, size, I2C_TIMEOUT) != HAL_OK){
+        #ifdef DEBUG
+            debug_print("I2C HAL Error receiving NAV-STATUS response\r\n");
+        #endif
+        return UBLOX_ERROR;
+    }
+
+    // Verify sync chars
+    if (buff[0] != UBX_SYNC_CHAR_1 || buff[1] != UBX_SYNC_CHAR_2) {
+        return UBLOX_INVALID_DATA;
+    }
+    // Verify message class and ID
+    if (buff[2] != UBX_CLASS_NAV || buff[3] != UBX_NAV_STATUS) {
+        return UBLOX_INVALID_DATA;
+    }
+    // Copy payload into packet structure
+    memcpy(&ubx_packet.payload.nav_status, &buff[UBX_HEADER_LENGTH], UBX_NAV_STATUS_LEN);
+    
+    // Set frame to valid
+    ubx_packet.valid = true;
+
+    // Returns UBX_OK if fix is valid and time is valid
+    return process_nav_status();
+}
+
+/**
+ * @brief Retrieves navigation PVT data from the GNSS module
+ * @details Requests NAV-PVT message which provides position, velocity, and time data
+ * @return Returns UBLOX_OK if fix is valid and time is valid; else UBLOX_ERROR_XX
+ */
+ublox_status_e ublox_get_pvt(void){
+    bool ack_only = false; // Expect full response
+
+    if(!ublox_initialized){
+        #ifdef DEBUG
+            debug_print("GPS module not initialized!\r\n");
+        #endif
+        return UBLOX_NOT_INITIALIZED;
+    }
+    if(ubx_packet.valid){
+        #ifdef DEBUG
+            debug_print("Packet is valid, previous frame not processed correctly\r\n");
+        #endif
+        return UBLOX_PACKET_NEEDS_PROCESSING;
+    }
+    // Always clear the packet before sending a new request
+    memset(&ubx_packet, 0, UBX_PACKET_LENGTH); 
+
+    // Setup packet for nav PVT request
+    ubx_packet.cls = UBX_CLASS_NAV;
+    ubx_packet.id = UBX_NAV_PVT;
+
+    #ifdef DEBUG
+        debug_print("Requesting NAV-PVT...\r\n");
+    #endif
+
+    if(ublox_send_command(ack_only) != UBLOX_OK){
+        #ifdef DEBUG
+            debug_print("Error sending NAV-PVT request\r\n");
+        #endif
+        return UBLOX_ERROR;
+    }
+
+    // Command sent now read the response
+    uint16_t size = UBX_HEADER_LENGTH + UBX_NAV_PVT_LEN + UBX_CHECKSUM_LENGTH;
+    uint8_t buff[size];
+
+    if(HAL_I2C_Master_Receive(&hi2c1, UBLOX_I2C_ADDR, buff, size, I2C_TIMEOUT) != HAL_OK){
+        #ifdef DEBUG
+            debug_print("I2C HAL Error receiving NAV-PVT response\r\n");
+        #endif
+        return UBLOX_ERROR;
+    }
+
+    // Verify sync chars
+    if (buff[0] != UBX_SYNC_CHAR_1 || buff[1] != UBX_SYNC_CHAR_2) {
+        return UBLOX_INVALID_DATA;
+    }
+    // Verify message class and ID
+    if (buff[2] != UBX_CLASS_NAV || buff[3] != UBX_NAV_PVT) {
+        return UBLOX_INVALID_DATA;
+    }
+    // Copy payload into packet structure
+    memcpy(&ubx_packet.payload.nav_pvt, &buff[UBX_HEADER_LENGTH], UBX_NAV_PVT_LEN);
+    
+    // Set frame to valid
+    ubx_packet.valid = true;
+
+    // Returns UBX_OK if fix is valid and time is valid
+    return validate_nav_pvt(); 
+}
+
+/**
+ * @brief Get lat, lon, height, and time from the gnss module
+ * @details The ublox module returns the lat and lon in deg * 1e-7, and for height this returns
+ *          the height above mean sea level in mm. All values from the module are 32 bit, signed integers (twos-complement). 
+ * 
+ */
+ublox_status_e ublox_get_curr_position(int32_t *lat, int32_t *lon, int32_t *height) {
+    if(!ubx_packet.valid){
+        #ifdef DEBUG
+            debug_print("Packet is invalid, cannot get position\r\n");
+        #endif
+        return UBLOX_INVALID_DATA;
+    }
+    *lat = ubx_packet.payload.nav_pvt.lat;
+    *lon = ubx_packet.payload.nav_pvt.lon;
+    *height = ubx_packet.payload.nav_pvt.hMSL; 
+
+    return UBLOX_OK;
+}
+
+/*******************************************************************************
+ * Private Function Implementations
+ ******************************************************************************/
+
+/**
+ * @brief Sends a UBX command packet to the GPS module
+ * @details Calculates checksum, formats packet according to UBX protocol,
+ *          and handles I2C transmission
+ */
+static ublox_status_e ublox_send_command(bool expect_ack_only){
+    calc_check_sum();
+
+    #ifdef DEBUG
+        debug_print("Sending UBX command...\r\n");
+    #endif   
+    
+    //Calculate the size of the transaction (header + payload + checksum)
+    uint16_t size = set_transaction_size(ubx_packet.len);
+
+    // Should never be zero 
+    if (size == 0){ 
+        return UBLOX_ERROR;
+    }
+
     uint8_t buff[size];
     buff[0] = UBX_SYNC_CHAR_1;
     buff[1] = UBX_SYNC_CHAR_2;
-    buff[2] = outgoing_ubx->cls;
-    buff[3] = outgoing_ubx->id;
-    buff[4] = outgoing_ubx->len & 0xFF;     //LSB
-    buff[5] = outgoing_ubx->len >> 8;       // MSB
+    buff[2] = ubx_packet.cls;
+    buff[3] = ubx_packet.id;
+    buff[4] = ubx_packet.len & 0xFF;     //LSB
+    buff[5] = ubx_packet.len >> 8;       // MSB
     uint16_t i = 0; 
-    for(; i < outgoing_ubx->len; i++){
+    for(; i < ubx_packet.len; i++){
         // TODO: Add error check here so payload and i don't go out of bounds
-        buff[i + 6] = outgoing_ubx->payload[i];
+        buff[i + 6] = ubx_packet.payload.raw[i];
     }
-    buff[i + 6] = outgoing_ubx->checksumA;
-    buff[i + 7] = outgoing_ubx->checksumB;
+    buff[i + 6] = ubx_packet.checksumA;
+    buff[i + 7] = ubx_packet.checksumB;
 
     // Send the data on bus
     if(HAL_I2C_Master_Transmit(&hi2c1, UBLOX_I2C_ADDR, buff, size, I2C_TIMEOUT) != HAL_OK){
         return UBLOX_ERROR;
     }
+    // After sending command always clear the valid bits since we expect a 
+    // response from the module
+    ubx_packet.valid = 0;
+
+    #ifdef DEBUG
+        debug_print("Sent UBX command...\r\n");
+    #endif 
+    HAL_Delay(1000); // IMPORTANT: A small delay is needed to allow the module to process the command 
+                     // before the requestor can read the response. I tried 100 ms and adjusted until 
+                     // finding that 1000 ms was the sweet spot and allowed the module enough time to process 
+                     // a command. 
     
     if(expect_ack_only) {
-        uint8_t rx_buff[10];
-        HAL_Delay(1000);
-        if(HAL_I2C_Master_Receive(&hi2c1, UBLOX_I2C_ADDR, rx_buff, 10, I2C_TIMEOUT) != HAL_OK){
-            return UBLOX_ERROR; 
+        // Parse the ACK/NACK response
+        return parse_ack_response(); 
+    }
+    return UBLOX_OK;
+}
+/**
+ * @brief Process NAV Status response from the u-blox module
+ * @return ublox_status_e UBX_OK if gps fix is valid, and time is valid; else UBX_ERROR
+ */
+static ublox_status_e process_nav_status(void) {
+    // Simple error check to see that the packet is valid
+    if(!ubx_packet.valid){
+        return UBLOX_INVALID_DATA;
+    }
+    // Check if fix is valid
+    if(ubx_packet.payload.nav_status.flags.bits.gpsFixOk != 1) {
+        #ifdef DEBUG
+            debug_print("GPS fix not valid\r\n");
+        #endif
+        return UBLOX_ERROR;
+    }
+    // Check if time is valid
+    if((ubx_packet.payload.nav_status.flags.bits.wknSet && ubx_packet.payload.nav_status.flags.bits.towSet) != 1) {
+        #ifdef DEBUG
+            debug_print("Time not valid\r\n");
+        #endif
+        return UBLOX_ERROR;
+    }
+    // Reset the packet to invalid since processing is complete
+    ubx_packet.valid = 0;
+    return UBLOX_OK;
+}
+
+/**
+ * @brief validate_nav_pvt helper function to validate the packet before exposing the data to the user
+ * 
+ */
+static ublox_status_e validate_nav_pvt(void) {
+    // Simple error check to see that the packet is valid
+    if(!ubx_packet.valid){
+        return UBLOX_INVALID_DATA;
+    }
+    // Check if date and time are valid
+    if(ubx_packet.payload.nav_pvt.valid.bits.validDate != 1 || ubx_packet.payload.nav_pvt.valid.bits.validTime != 1) {
+        #ifdef DEBUG
+            debug_print("Date or time not valid\r\n");
+        #endif
+        // Set to invalid
+        ubx_packet.valid = 0;
+        return UBLOX_ERROR;
+    }
+    // Check if fix is valid
+    if(ubx_packet.payload.nav_pvt.flags.bits.gnssFixOK != 1) {
+        #ifdef DEBUG
+            debug_print("GPS fix not valid\r\n");
+        #endif
+        // Set to invalid
+        ubx_packet.valid = 0;
+        return UBLOX_ERROR;
+    }
+    // Checks passed, return OK. User can now access the data
+    return UBLOX_OK;
+}
+
+/**
+ * @brief Parses ACK/NACK response from the u-blox module
+ * @param rx_buff Pointer to received data buffer
+ * @param rx_len Length of received data
+ * @return ublox_status_e UBX_OK if ACK received, UBX_ERROR if NACK or invalid response
+ * @note TODO: function does not check error codes
+ */
+static ublox_status_e parse_ack_response(void) {
+    uint16_t size = 10;                        // Ack response is always 8 bytes
+    uint8_t buff[size]; 
+    if(HAL_I2C_Master_Receive(&hi2c1, UBLOX_I2C_ADDR, buff, size, I2C_TIMEOUT) != HAL_OK){
+        return UBLOX_ERROR;
+    }
+
+    // Check sync chars
+    if (buff[0] != UBX_SYNC_CHAR_1 || buff[1] != UBX_SYNC_CHAR_2) {
+        #ifdef DEBUG
+            debug_print("Invalid sync chars in ACK response\r\n");
+        #endif
+        return UBLOX_INVALID_DATA;
+    }
+    // Check class and ID for ACK-ACK (0x05 0x01) or ACK-NACK (0x05 0x00)
+    if (buff[2] != UBX_CLASS_ACK) {
+        #ifdef DEBUG
+            debug_print("Invalid class in ACK response\r\n");
+        #endif
+        return UBLOX_INVALID_DATA;
+    }
+    if (buff[3] == UBX_ACK_NACK){
+        #ifdef DEBUG
+            debug_print("Received NACK\r\n");
+        #endif
+        return UBLOX_NACK_ERROR;
+    } 
+    else if (buff[3] == UBX_ACK_ACK) {
+        #ifdef DEBUG
+            debug_print("Received ACK\r\n");
+        #endif
+        // Length should be 2 bytes, skip these since we know if will always be 2 here
+        if(buff[6] == ubx_packet.cls && buff[7] == ubx_packet.id){
+            #ifdef DEBUG
+                debug_print("ACK payload matches sent command\r\n");
+            #endif
+            return UBLOX_OK;
         }
-        //Parse incoming datas ack 
-    }
-
-    
-    return UBLOX_OK;
+        else{
+            #ifdef DEBUG
+                debug_print("ACK payload does not match sent command\r\n");
+            #endif
+            return UBLOX_ERROR;
+        }
+    } 
+    // Should never reach here, unknown response
+    return UBLOX_ERROR;
 }
-/* TODO Remove me later
-// Private function
-static UBLOX_Status_t ublox_send_command(ubx_packet_t *outgoing_ubx, bool expect_ack_only){
-    //TODO: Implement this function
-    calc_check_sum(outgoing_ubx);
 
-    #ifdef DEBUG
-        HAL_UART_Transmit(&huart2, ublox_transmits_msg, sizeof(ublox_transmits_msg), 10);
-    #endif   
-    //uint16_t bytes_left_to_send = outgoing_ubx->len;
-    //uint16_t start_spot = 0; 
-    
-    //to set transaction size
-    uint16_t size = set_transaction_size(outgoing_ubx->len);
-    if (size == 0){ // Should never be zero 
-        return UBLOX_ERROR;
-    }
-    uint8_t buff[size];
-    buff[0] = UBX_SYNC_CHAR_1;
-    buff[1] = UBX_SYNC_CHAR_2;
-    buff[2] = outgoing_ubx->cls;
-    buff[3] = outgoing_ubx->id;
-    buff[4] = outgoing_ubx->len & 0xFF;
-    buff[5] = outgoing_ubx->len >> 8;
-    uint16_t i = 0; 
-    for(; i < outgoing_ubx->len; i++){
-        // TODO: Add error check here so payload and i don't go out of bounds
-        buff[i + 6] = outgoing_ubx->payload[i];
-    }
-    buff[i + 6] = outgoing_ubx->checksumA;
-    buff[i + 7] = outgoing_ubx->checksumB;
-
-    // Send the data on bus
-    if(HAL_I2C_Master_Transmit(&hi2c1, UBLOX_I2C_ADDR, buff, size, I2C_TIMEOUT) != HAL_OK){
-        return UBLOX_ERROR;
-    }
-    // Now read the response
-    uint8_t rx_size = UBX_HEADER_LENGTH + UBX_NAV_STATUS_LEN + UBX_CHECKSUM_LENGTH; 
-    uint8_t rx_buff[UBX_MAX_PACKET_LENGTH];
-
-    // Read response
-    if(HAL_I2C_Master_Receive(&hi2c1, UBLOX_I2C_ADDR, rx_buff, rx_size, I2C_TIMEOUT) != HAL_OK){
-        return UBLOX_ERROR;
-    }
-
-    //TODO: need to parse data from buffer
-
-    
-    return UBLOX_OK;
-}
-*/
-
-// Fletch Checksum Algorithm
-static void calc_check_sum(ubx_packet_t *outgoing_ubx) {
+/**
+ * @brief Calculates Fletcher checksum for UBX packet
+ * 
+ * @details Implements the Fletcher checksum algorithm for UBX protocol packets.
+ *          Calculates checksums over class, ID, length, and payload bytes.
+ *          The algorithm uses two running sums (checksumA and checksumB) where:
+ *          - checksumA is a simple sum of bytes
+ *          - checksumB is a sum of all checksumA values
+ * 
+ * @param outgoing_ubx Pointer to UBX packet structure containing data to checksum
+ * 
+ * @note Checksum calculation order:
+ *       1. Class byte
+ *       2. ID byte
+ *       3. Length bytes (little endian)
+ *       4. All payload bytes (if present)
+ */
+static void calc_check_sum() {
     // Reset checksums
-    outgoing_ubx->checksumA = 0;
-    outgoing_ubx->checksumB = 0;
+    ubx_packet.checksumA = 0;
+    ubx_packet.checksumB = 0;
     
     // Add class
-    outgoing_ubx->checksumA += outgoing_ubx->cls;
-    outgoing_ubx->checksumB += outgoing_ubx->checksumA;
+    ubx_packet.checksumA += ubx_packet.cls;
+    ubx_packet.checksumB += ubx_packet.checksumA;
     
     // Add ID
-    outgoing_ubx->checksumA += outgoing_ubx->id;
-    outgoing_ubx->checksumB += outgoing_ubx->checksumA;
+    ubx_packet.checksumA += ubx_packet.id;
+    ubx_packet.checksumB += ubx_packet.checksumA;
     
     // Add length (2 bytes, little endian)
-    outgoing_ubx->checksumA += (outgoing_ubx->len & 0xFF);
-    outgoing_ubx->checksumB += outgoing_ubx->checksumA;
+    ubx_packet.checksumA += (ubx_packet.len & 0xFF);
+    ubx_packet.checksumB += ubx_packet.checksumA;
     
-    outgoing_ubx->checksumA += (outgoing_ubx->len >> 8);
-    outgoing_ubx->checksumB += outgoing_ubx->checksumA;
+    ubx_packet.checksumA += (ubx_packet.len >> 8);
+    ubx_packet.checksumB += ubx_packet.checksumA;
     
     // Add payload bytes if there are any
-    if(outgoing_ubx->payload != NULL && outgoing_ubx->len > 0) {
-        for(uint16_t i = 0; i < outgoing_ubx->len; i++) {
-            outgoing_ubx->checksumA += outgoing_ubx->payload[i];
-            outgoing_ubx->checksumB += outgoing_ubx->checksumA;
+    if(ubx_packet.len > 0) {
+        for(uint16_t i = 0; i < ubx_packet.len; i++) {
+            ubx_packet.checksumA += ubx_packet.payload.raw[i];
+            ubx_packet.checksumB += ubx_packet.checksumA;
         }
-    }
-    
+    } 
 }
 
+
+/**
+ * @brief Calculates and validates total transaction size for I2C communication
+ * 
+ * @details Calculates the total packet size including:
+ *          - 6 bytes header (2 sync + 1 class + 1 ID + 2 length)
+ *          - N bytes payload
+ *          - 2 bytes checksum
+ *          Validates that the total size doesn't exceed maximum packet length
+ * 
+ * @param len Length of payload in bytes
+ * @return uint16_t Total transaction size if valid, 0 if size would exceed maximum
+ * 
+ * @note Debug message is output if size validation fails
+ */
 static uint16_t set_transaction_size(uint16_t len){
     // Number of bytes written is payload length + 8 bytes for header and checksum
     uint16_t size = len + 8;
-    if(size > UBX_MAX_PACKET_LENGTH){
+    if(size > UBX_PACKET_LENGTH){
         #ifdef DEBUG
-            HAL_UART_Transmit(&huart2, ublox_transaction_size_overflow, sizeof(ublox_transaction_size_overflow), 10);
+            debug_print("Packet size exceeds maximum length!\r\n");
         #endif
         return 0; // Error
     } 
     return size;   
 }
 
-
-// Config setting
-static UBLOX_Status_t ublox_set_i2c_output(comm_type_t comm_settings) {
-    if(!ublox_initialized) {
-        #ifdef DEBUG
-            HAL_UART_Transmit(&huart2, ublox_error_init, sizeof(ublox_error_init), 10);
-        #endif
-        return UBLOX_NOT_INITIALIZED;
-    }
-
+/**
+ * @brief Configures the I2C output protocol settings of the u-blox module
+ * 
+ * @details Sets up the module to use specified protocol (UBX/NMEA) over I2C.
+ *          Uses CFG-VALSET message to configure the I2COUTPROT setting.
+ *          Configuration is stored in battery-backed RAM (BBRAM) to persist
+ *          during power cycles while backup power is maintained.
+ * 
+ * @param comm_settings Communication protocol selection (UBX or NMEA)
+ * @return ublox_status_e UBLOX_OK if configuration successful, error code otherwise
+ * 
+ * @note Configuration requires acknowledgment from module to confirm success
+ */
+static ublox_status_e set_ubx_i2c_output(ublox_comm_type_e comm_settings) {
     //Clear packet structure
+    if(comm_settings != UBX){
+        return UBLOX_ERROR;
+    }
     memset(&ubx_packet, 0, sizeof(ubx_packet_t));
 
     // Setup packet for CFG-VALSET message
     ubx_packet.cls = UBX_CLASS_CFG; 
     ubx_packet.id = UBX_CFG_VALSET;
+    ubx_packet.len = 9;
+        
+    ubx_packet.payload.raw[0] = 0x00;   // Version
+    ubx_packet.payload.raw[1] = 0x11;   // Layer = BBRAM (0x10) | RAM (0x01) see pg. 125 of Interface Description
+    ubx_packet.payload.raw[2] = 0x00;   // Reserved
+    ubx_packet.payload.raw[3] = 0x00;   // Reserved
+
+    ubx_packet.payload.raw[4] = 0x01;   // LSB: Key ID (0x10720001)
+    ubx_packet.payload.raw[5] = 0x00;   // CFG-I2COUTPROT-UBX
+    ubx_packet.payload.raw[6] = 0x72;   //
+    ubx_packet.payload.raw[7] = 0x10;   // MSB: Key ID
+    ubx_packet.payload.raw[8] = 0x01;   // Value = UBX protocol
+
+    ublox_status_e status = ublox_send_command(true);
+    if(status != UBLOX_OK){
+        return status;
+    }
     
-    // Payload for CFG-VALSET
-    uint8_t payload[] = {
-        0x00,        // version 
-        0x01,        // layer = RAM only
-        0x00, 0x00,  // reserved0
-        // CFG-I2COUTPROT-UBX key-value pair
-        0x01, 0x00, 0x72, 0x10,  // Key ID (0x10720001)
-    };
+    // Set the I2C output protocol to UBX
+    memset(&ubx_packet, 0, sizeof(ubx_packet_t));
+    ubx_packet.cls = UBX_CLASS_CFG;
+    ubx_packet.id = UBX_CFG_VALSET;  // CFG-VALSET command ID
+    ubx_packet.len = 9;   
 
-    ubx_packet.len = sizeof(payload);
-    ubx_packet.payload = payload;
+    ubx_packet.payload.raw[0] = 0x00;   // Version
+    ubx_packet.payload.raw[1] = 0x11;   // Layer = BBRAM (0x10) | RAM (0x01) see pg. 125 of Interface Description
+    ubx_packet.payload.raw[2] = 0x00;   // Reserved
+    ubx_packet.payload.raw[3] = 0x00;   // Reserved
 
-    // Send command and wait for ACK
-    return ublox_send_command(&ubx_packet, true);
+    ubx_packet.payload.raw[4] = 0x02;   // LSB: Key ID (0x10720002)
+    ubx_packet.payload.raw[5] = 0x00;   // CFG-I2COUTPROT-NMEA
+    ubx_packet.payload.raw[6] = 0x72;   //
+    ubx_packet.payload.raw[7] = 0x10;   // MSB: Key ID
+    ubx_packet.payload.raw[8] = 0x00;   // Value = NMEA protocol (i.e. disable NMEA)
+
+    return ublox_send_command(true);
 }
 
-
+ublox_status_e ublox_reset(void) {
+    memset(&ubx_packet, 0, UBX_PACKET_LENGTH);
+    
+    ubx_packet.cls = UBX_CLASS_CFG;
+    ubx_packet.id = 0x04;  // Reset command ID
+    ubx_packet.len = 4;    // navBbrMask (X2) + resetMode (U1) + reserved (U1)
+    
+    // Set payload
+    ubx_packet.payload.raw[0] = 0xFF;   // Clear all BBR sections
+    ubx_packet.payload.raw[1] = 0xFF;   // Clear all BBR sections
+    ubx_packet.payload.raw[2] = 0x00;   // Hardware reset
+    ubx_packet.payload.raw[3] = 0x00;   // Reserved byte
+    
+    return ublox_send_command(false);  // Expect ACK
+}
 
 
 

--- a/libs/gps/Src/u-blox_gnss_MAX-M10S.c
+++ b/libs/gps/Src/u-blox_gnss_MAX-M10S.c
@@ -1,3 +1,245 @@
+/*
+File u-blox_gnss_MAX-M10S.c
+*/
+
 #include "u-blox_gnss_MAX-M10S.h"
+
+// Private function headers
+static UBLOX_Status_t ublox_send_command(ubx_packet_t *outgoing_ubx, bool expect_ack_only);
+static void calc_check_sum(ubx_packet_t *outgoing_ubx);
+static uint16_t set_transaction_size(uint16_t len);
+static UBLOX_Status_t ublox_set_i2c_output(comm_type_t comm_settings);
+
+// Private initialization flag might need to fix this
+static bool ublox_initialized = false;
+extern UART_HandleTypeDef huart2;
+
+#ifdef DEBUG 
+    const uint8_t ublox_error_init[] = "u-blox GNSS Module not initialized. Call ublox_init() first.\r\n";
+    const uint8_t ublox_error_memset[] = "Memory allocation failed. Check if memory is available.\r\n";
+    const uint8_t ublox_error_i2c[] = "I2C peripheral not initialized. Check I2C configuration.\r\n";
+    const uint8_t ublox_packet_error[] = "u-blox packet error. Check packet validity.\r\n";
+    const uint8_t ublox_transmits_msg[] = "Requesting data from u-blox.\r\n";
+    const uint8_t ublox_transaction_size_overflow[] = "Transaction size overflow. Check packet length.\r\n";
+#endif
+
+UBLOX_Status_t ublox_init(void){
+    // Initialize the I2C peripheral
+    MX_I2C1_Init();
+    // Zero packet structure
+    memset(&ubx_packet, 0, sizeof(ubx_packet_t));
+    ublox_initialized = true;
+
+    UBLOX_Status_t status = ublox_set_i2c_output(UBX);
+    if(status != UBLOX_OK)
+        return status; 
+        
+    return UBLOX_OK;
+}
+
+
+// Based on sparkfun's getNAVSTATUS(uint16_t maxWait = kUBLOXGNSSDefaultMaxWait); func
+UBLOX_Status_t ublox_get_nav_status(void){
+    // Check if the module has been initialized
+    bool ack_only = false;
+    if(!ublox_initialized){
+        #ifdef DEBUG
+            HAL_UART_Transmit(&huart2, ublox_error_init, sizeof(ublox_error_init), 10);
+        #endif
+        return UBLOX_NOT_INITIALIZED;
+    }
+    if(ubx_packet.valid.bits.packet){
+        #ifdef DEBUG
+            HAL_UART_Transmit(&huart2, ublox_packet_error, sizeof(ublox_packet_error), 10);
+        #endif
+        return UBLOX_PACKET_NEEDS_PROCESSING;
+    }
+    memset(&ubx_packet, 0, sizeof(ubx_packet_t)); // Clear the packet before sending a new request
+    ubx_packet.cls = UBX_CLASS_NAV;
+    ubx_packet.id = UBX_NAV_STATUS;
+
+    UBLOX_Status_t status = ublox_send_command(&ubx_packet, ack_only);
+    return status;
+}
+
+
+// Private function
+static UBLOX_Status_t ublox_send_command(ubx_packet_t *outgoing_ubx, bool expect_ack_only){
+    //TODO: Implement this function
+    calc_check_sum(outgoing_ubx);
+
+    #ifdef DEBUG
+        HAL_UART_Transmit(&huart2, ublox_transmits_msg, sizeof(ublox_transmits_msg), 10);
+    #endif   
+    //uint16_t bytes_left_to_send = outgoing_ubx->len;
+    //uint16_t start_spot = 0; 
+    
+    //to set transaction size
+    uint16_t size = set_transaction_size(outgoing_ubx->len);
+    if (size == 0){ // Should never be zero 
+        return UBLOX_ERROR;
+    }
+    uint8_t buff[size];
+    buff[0] = UBX_SYNC_CHAR_1;
+    buff[1] = UBX_SYNC_CHAR_2;
+    buff[2] = outgoing_ubx->cls;
+    buff[3] = outgoing_ubx->id;
+    buff[4] = outgoing_ubx->len & 0xFF;     //LSB
+    buff[5] = outgoing_ubx->len >> 8;       // MSB
+    uint16_t i = 0; 
+    for(; i < outgoing_ubx->len; i++){
+        // TODO: Add error check here so payload and i don't go out of bounds
+        buff[i + 6] = outgoing_ubx->payload[i];
+    }
+    buff[i + 6] = outgoing_ubx->checksumA;
+    buff[i + 7] = outgoing_ubx->checksumB;
+
+    // Send the data on bus
+    if(HAL_I2C_Master_Transmit(&hi2c1, UBLOX_I2C_ADDR, buff, size, I2C_TIMEOUT) != HAL_OK){
+        return UBLOX_ERROR;
+    }
+    
+    if(expect_ack_only) {
+        uint8_t rx_buff[10];
+        HAL_Delay(1000);
+        if(HAL_I2C_Master_Receive(&hi2c1, UBLOX_I2C_ADDR, rx_buff, 10, I2C_TIMEOUT) != HAL_OK){
+            return UBLOX_ERROR; 
+        }
+        //Parse incoming datas ack 
+    }
+
+    
+    return UBLOX_OK;
+}
+/* TODO Remove me later
+// Private function
+static UBLOX_Status_t ublox_send_command(ubx_packet_t *outgoing_ubx, bool expect_ack_only){
+    //TODO: Implement this function
+    calc_check_sum(outgoing_ubx);
+
+    #ifdef DEBUG
+        HAL_UART_Transmit(&huart2, ublox_transmits_msg, sizeof(ublox_transmits_msg), 10);
+    #endif   
+    //uint16_t bytes_left_to_send = outgoing_ubx->len;
+    //uint16_t start_spot = 0; 
+    
+    //to set transaction size
+    uint16_t size = set_transaction_size(outgoing_ubx->len);
+    if (size == 0){ // Should never be zero 
+        return UBLOX_ERROR;
+    }
+    uint8_t buff[size];
+    buff[0] = UBX_SYNC_CHAR_1;
+    buff[1] = UBX_SYNC_CHAR_2;
+    buff[2] = outgoing_ubx->cls;
+    buff[3] = outgoing_ubx->id;
+    buff[4] = outgoing_ubx->len & 0xFF;
+    buff[5] = outgoing_ubx->len >> 8;
+    uint16_t i = 0; 
+    for(; i < outgoing_ubx->len; i++){
+        // TODO: Add error check here so payload and i don't go out of bounds
+        buff[i + 6] = outgoing_ubx->payload[i];
+    }
+    buff[i + 6] = outgoing_ubx->checksumA;
+    buff[i + 7] = outgoing_ubx->checksumB;
+
+    // Send the data on bus
+    if(HAL_I2C_Master_Transmit(&hi2c1, UBLOX_I2C_ADDR, buff, size, I2C_TIMEOUT) != HAL_OK){
+        return UBLOX_ERROR;
+    }
+    // Now read the response
+    uint8_t rx_size = UBX_HEADER_LENGTH + UBX_NAV_STATUS_LEN + UBX_CHECKSUM_LENGTH; 
+    uint8_t rx_buff[UBX_MAX_PACKET_LENGTH];
+
+    // Read response
+    if(HAL_I2C_Master_Receive(&hi2c1, UBLOX_I2C_ADDR, rx_buff, rx_size, I2C_TIMEOUT) != HAL_OK){
+        return UBLOX_ERROR;
+    }
+
+    //TODO: need to parse data from buffer
+
+    
+    return UBLOX_OK;
+}
+*/
+
+// Fletch Checksum Algorithm
+static void calc_check_sum(ubx_packet_t *outgoing_ubx) {
+    // Reset checksums
+    outgoing_ubx->checksumA = 0;
+    outgoing_ubx->checksumB = 0;
+    
+    // Add class
+    outgoing_ubx->checksumA += outgoing_ubx->cls;
+    outgoing_ubx->checksumB += outgoing_ubx->checksumA;
+    
+    // Add ID
+    outgoing_ubx->checksumA += outgoing_ubx->id;
+    outgoing_ubx->checksumB += outgoing_ubx->checksumA;
+    
+    // Add length (2 bytes, little endian)
+    outgoing_ubx->checksumA += (outgoing_ubx->len & 0xFF);
+    outgoing_ubx->checksumB += outgoing_ubx->checksumA;
+    
+    outgoing_ubx->checksumA += (outgoing_ubx->len >> 8);
+    outgoing_ubx->checksumB += outgoing_ubx->checksumA;
+    
+    // Add payload bytes if there are any
+    if(outgoing_ubx->payload != NULL && outgoing_ubx->len > 0) {
+        for(uint16_t i = 0; i < outgoing_ubx->len; i++) {
+            outgoing_ubx->checksumA += outgoing_ubx->payload[i];
+            outgoing_ubx->checksumB += outgoing_ubx->checksumA;
+        }
+    }
+    
+}
+
+static uint16_t set_transaction_size(uint16_t len){
+    // Number of bytes written is payload length + 8 bytes for header and checksum
+    uint16_t size = len + 8;
+    if(size > UBX_MAX_PACKET_LENGTH){
+        #ifdef DEBUG
+            HAL_UART_Transmit(&huart2, ublox_transaction_size_overflow, sizeof(ublox_transaction_size_overflow), 10);
+        #endif
+        return 0; // Error
+    } 
+    return size;   
+}
+
+
+// Config setting
+static UBLOX_Status_t ublox_set_i2c_output(comm_type_t comm_settings) {
+    if(!ublox_initialized) {
+        #ifdef DEBUG
+            HAL_UART_Transmit(&huart2, ublox_error_init, sizeof(ublox_error_init), 10);
+        #endif
+        return UBLOX_NOT_INITIALIZED;
+    }
+
+    //Clear packet structure
+    memset(&ubx_packet, 0, sizeof(ubx_packet_t));
+
+    // Setup packet for CFG-VALSET message
+    ubx_packet.cls = UBX_CLASS_CFG; 
+    ubx_packet.id = UBX_CFG_VALSET;
+    
+    // Payload for CFG-VALSET
+    uint8_t payload[] = {
+        0x00,        // version 
+        0x01,        // layer = RAM only
+        0x00, 0x00,  // reserved0
+        // CFG-I2COUTPROT-UBX key-value pair
+        0x01, 0x00, 0x72, 0x10,  // Key ID (0x10720001)
+    };
+
+    ubx_packet.len = sizeof(payload);
+    ubx_packet.payload = payload;
+
+    // Send command and wait for ACK
+    return ublox_send_command(&ubx_packet, true);
+}
+
+
+
 
 

--- a/tests/test_gps/CMakeLists.txt
+++ b/tests/test_gps/CMakeLists.txt
@@ -39,29 +39,29 @@ message("Target MCU: ${TARGET_MCU}")
 # Create executable
 add_executable(${PROJECT_NAME})
 
-# FIXME: Add test sources
+# Add test sources
 target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_SOURCE_DIR}/test_gps.c
 )
 
-# FIXME: Add include paths
+# Add include paths
 target_include_directories(${PROJECT_NAME} PRIVATE
     ${CMAKE_SOURCE_DIR}/../../Config/Inc
 )
 
 # Add STM32CubeMX generated sources
-# add_subdirectory(${CUBEMX_PATH} ${CMAKE_BINARY_DIR}/stm32cubemx)
 add_subdirectory(
     ${CUBEMX_PATH}/                       # Source directory
     ${CMAKE_BINARY_DIR}/stm32cubemx       # Binary directory
 )
 
 add_subdirectory(
-    ${CMAKE_SOURCE_DIR}/../../libs/gps
-    ${CMAKE_BINARY_DIR}/gps
+    ${CMAKE_SOURCE_DIR}/../../libs
+    ${CMAKE_BINARY_DIR}/libs
 )
 
 target_link_libraries(${PROJECT_NAME} 
     stm32cubemx
     ublox_gps_driver
+    common
 )

--- a/tests/test_gps/CMakeLists.txt
+++ b/tests/test_gps/CMakeLists.txt
@@ -46,7 +46,7 @@ target_sources(${PROJECT_NAME} PRIVATE
 
 # FIXME: Add include paths
 target_include_directories(${PROJECT_NAME} PRIVATE
-    #Example ${CMAKE_SOURCE_DIR}/../../Src/Sensors/Inc
+    ${CMAKE_SOURCE_DIR}/../../Config/Inc
 )
 
 # Add STM32CubeMX generated sources
@@ -56,6 +56,12 @@ add_subdirectory(
     ${CMAKE_BINARY_DIR}/stm32cubemx       # Binary directory
 )
 
+add_subdirectory(
+    ${CMAKE_SOURCE_DIR}/../../libs/gps
+    ${CMAKE_BINARY_DIR}/gps
+)
+
 target_link_libraries(${PROJECT_NAME} 
     stm32cubemx
+    ublox_gps_driver
 )

--- a/tests/test_gps/test_gps.c
+++ b/tests/test_gps/test_gps.c
@@ -1,86 +1,149 @@
-#include "main.h"     // For HAL definitions and Error_Handler
-#include "gpio.h"     // For GPIO functions
-#include "i2c.h"      // For I2C functions
-#include "usart.h"    // For UART functions
-#include "test_gps.h" // 
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_hal.h"
+#include "main.h"
+#include "gpio.h"
+#include "i2c.h"
+#include "usart.h"
 #include <string.h>
+#include <stdio.h>
+#include <ctype.h>
 #include "u-blox_gnss_MAX-M10S.h"
 
-#ifdef DEBUG 
-  #define DEBUG_UART huart2
-  #define debug_print(msg) do{ \
-    HAL_UART_Transmit(&DEBUG_UART, (uint8_t*)(msg), strlen(msg), 100); \
-  } while(0)
-#endif
+/* Private variables ---------------------------------------------------------*/
+uint8_t rx_char;
+ublox_status_e status;
+char debug_buff[100];  // Buffer for debug messages
 
-uint8_t rx_char; 
-UBLOX_Status_t status;
+/* Private function prototypes -----------------------------------------------*/
+static void print_location_data(void);
+static void process_command(uint8_t cmd);
 
 int main(void)
 {
   /* MCU Configuration--------------------------------------------------------*/
-
-  /* Reset of all peripherals, Initializes the Flash interface and the Systick. */
   HAL_Init();
-
-  /* Configure the system clock */
   SystemClock_Config();
-
-  /* Initialize all configured peripherals */
   MX_GPIO_Init();
-  //GPS handles init of I2C1
-  //MX_I2C1_Init();
   MX_USART1_UART_Init();
   MX_USART2_UART_Init();
-  while(1) {
-    // Wait to receive start char
-    if (HAL_UART_Receive(&DEBUG_UART, &rx_char, 1, 10) == HAL_OK){
-      if (rx_char == 'S' || rx_char == 's') {
-          #ifdef DEBUG
-            debug_print("Initing GPS with UBX command...\r\n");
-          #endif
-          rx_char = 0; 
-          break; 
-      }
-    }
-    HAL_Delay(1000);
-  }
-
-  if (ublox_init() != UBLOX_OK){
-    #ifdef DEBUG
-      debug_print("GPS initialization failed!\r\n");
-    #endif
-    Error_Handler(); 
-  } 
 
   #ifdef DEBUG
-    debug_print("System initialized. Send 'T' to trigger NAV status request\r\n");
+    debug_print("GPS Test Program\r\n");
+    debug_print("Available Commands:\r\n");
+    debug_print("'I' - Initialize GPS module\r\n");
+    debug_print("'F' - Check GPS Fix status\r\n");
+    debug_print("'L' - Get Location data (lat/lon/height)\r\n");
   #endif
-  
-  while (1)
-  {
-    // Test loop
-    // Check if we received a character
-    if (HAL_UART_Receive(&DEBUG_UART, &rx_char, 1, 10) == HAL_OK) {
-      if (rx_char == 'T' || rx_char == 't') {
+
+  // Wait for initialization command
+  while(1) {
+    if (HAL_UART_Receive(&huart2, &rx_char, 1, 10) == HAL_OK) {
+      if (rx_char == 'I' || rx_char == 'i') {
         #ifdef DEBUG
-          debug_print("Requesting NAV status...\r\n");
+          debug_print("Initializing GPS module...\r\n");
         #endif
-        
-        status = ublox_get_nav_status();
-        
+        if (ublox_init() != UBLOX_OK) {
+          #ifdef DEBUG
+            debug_print("GPS initialization failed!\r\n");
+          #endif
+          Error_Handler();
+        }
         #ifdef DEBUG
-          if (status == UBLOX_OK) {
-            debug_print("NAV status request sent successfully\r\n");
-          } else {
-            debug_print("NAV status request failed\r\n");
-          }
+          debug_print("GPS initialized successfully\r\n");
+          debug_print("Use 'F' to check fix status before requesting location\r\n");
         #endif
+        break;
       }
     }
-
-    // Blink LED to show the program is running
     HAL_GPIO_TogglePin(LD3_GPIO_Port, LD3_Pin);
     HAL_Delay(1000);
   }
+
+  /* Main loop --------------------------------------------------------------*/
+  while (1) {
+    // Check for commands
+    if (HAL_UART_Receive(&huart2, &rx_char, 1, 10) == HAL_OK) {
+      process_command(rx_char);
+    }
+    
+    // Heartbeat LED
+    HAL_GPIO_TogglePin(LD3_GPIO_Port, LD3_Pin);
+    HAL_Delay(500);
+  }
+}
+
+/**
+ * @brief Process received commands
+ * @param cmd Command character received
+ */
+static void process_command(uint8_t cmd) {
+  switch(toupper(cmd)) {
+    case 'F':  // Check Fix status
+      #ifdef DEBUG
+        debug_print("Checking GPS fix status...\r\n");
+      #endif
+      status = ublox_get_nav_status();
+      #ifdef DEBUG
+        if (status == UBLOX_OK) {
+          debug_print("Good GPS fix - Ready for location data\r\n");
+        } else {
+          debug_print("No GPS fix - Please wait for satellite acquisition\r\n");
+        }
+      #endif
+      break;
+
+    case 'L':  // Get Location data
+      #ifdef DEBUG
+        debug_print("Requesting location data...\r\n");
+      #endif
+      
+      // First get fresh PVT data
+      status = ublox_get_pvt();
+      if (status != UBLOX_OK) {
+        #ifdef DEBUG
+          debug_print("Failed to get location data - Check fix status\r\n");
+        #endif
+        return;
+      }
+
+      // Now get the position data
+      print_location_data();
+      break;
+
+    default:
+      #ifdef DEBUG
+        debug_print("Unknown command. Available commands:\r\n");
+        debug_print("'F' - Check GPS Fix status\r\n");
+        debug_print("'L' - Get Location data\r\n");
+      #endif
+      break;
+  }
+}
+
+/**
+ * @brief Print location data from GPS
+ */
+static void print_location_data(void) {
+  int32_t lat, lon, height;
+  
+  status = ublox_get_curr_position(&lat, &lon, &height);
+  if (status != UBLOX_OK) {
+    #ifdef DEBUG
+      debug_print("Error retrieving location data\r\n");
+    #endif
+    return;
+  }
+
+  #ifdef DEBUG
+    debug_print("Current Location (raw values):\r\n");
+    
+    snprintf(debug_buff, sizeof(debug_buff), "  Latitude:  %ld\r\n", lat);
+    debug_print(debug_buff);
+    
+    snprintf(debug_buff, sizeof(debug_buff), "  Longitude: %ld\r\n", lon);
+    debug_print(debug_buff);
+    
+    snprintf(debug_buff, sizeof(debug_buff), "  Altitude:  %ld\r\n", height);
+    debug_print(debug_buff);
+  #endif
 }

--- a/tests/test_gps/test_gps.c
+++ b/tests/test_gps/test_gps.c
@@ -3,6 +3,18 @@
 #include "i2c.h"      // For I2C functions
 #include "usart.h"    // For UART functions
 #include "test_gps.h" // 
+#include <string.h>
+#include "u-blox_gnss_MAX-M10S.h"
+
+#ifdef DEBUG 
+  #define DEBUG_UART huart2
+  #define debug_print(msg) do{ \
+    HAL_UART_Transmit(&DEBUG_UART, (uint8_t*)(msg), strlen(msg), 100); \
+  } while(0)
+#endif
+
+uint8_t rx_char; 
+UBLOX_Status_t status;
 
 int main(void)
 {
@@ -16,14 +28,58 @@ int main(void)
 
   /* Initialize all configured peripherals */
   MX_GPIO_Init();
-  MX_I2C1_Init();
+  //GPS handles init of I2C1
+  //MX_I2C1_Init();
   MX_USART1_UART_Init();
   MX_USART2_UART_Init();
+  while(1) {
+    // Wait to receive start char
+    if (HAL_UART_Receive(&DEBUG_UART, &rx_char, 1, 10) == HAL_OK){
+      if (rx_char == 'S' || rx_char == 's') {
+          #ifdef DEBUG
+            debug_print("Initing GPS with UBX command...\r\n");
+          #endif
+          rx_char = 0; 
+          break; 
+      }
+    }
+    HAL_Delay(1000);
+  }
 
-  /* Your test code here */
+  if (ublox_init() != UBLOX_OK){
+    #ifdef DEBUG
+      debug_print("GPS initialization failed!\r\n");
+    #endif
+    Error_Handler(); 
+  } 
+
+  #ifdef DEBUG
+    debug_print("System initialized. Send 'T' to trigger NAV status request\r\n");
+  #endif
+  
   while (1)
   {
     // Test loop
+    // Check if we received a character
+    if (HAL_UART_Receive(&DEBUG_UART, &rx_char, 1, 10) == HAL_OK) {
+      if (rx_char == 'T' || rx_char == 't') {
+        #ifdef DEBUG
+          debug_print("Requesting NAV status...\r\n");
+        #endif
+        
+        status = ublox_get_nav_status();
+        
+        #ifdef DEBUG
+          if (status == UBLOX_OK) {
+            debug_print("NAV status request sent successfully\r\n");
+          } else {
+            debug_print("NAV status request failed\r\n");
+          }
+        #endif
+      }
+    }
+
+    // Blink LED to show the program is running
     HAL_GPIO_TogglePin(LD3_GPIO_Port, LD3_Pin);
     HAL_Delay(1000);
   }

--- a/tests/test_gps/test_gps.h
+++ b/tests/test_gps/test_gps.h
@@ -1,9 +1,0 @@
-#pragma once
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-/* Includes ------------------------------------------------------------------*/
-#include "stm32l4xx_hal.h"
-


### PR DESCRIPTION
# Initial GPS Driver Implementation Complete

I've completed the core functionality of the MAX-M10S driver. The implementation maintains a small footprint of only 3.5KB, most of which is code and will be stored in flash. 273 bytes will occupy RAM space at runtime, and consists of the UBX frame structure. 

```bash
test_gps\build\Debug [ gps-lib][△ v3.28.1]
❯ arm-none-eabi-size libs/gps/CMakeFiles/ublox_gps_driver.dir/Src/u-blox_gnss_MAX-M10S.c.obj 
   text    data     bss     dec     hex filename
   3230       0     273    3503     daf libs/gps/CMakeFiles/ublox_gps_driver.dir/Src/u-blox_gnss_MAX-M10S.c.obj

test_gps\build\Debug [ gps-lib][△ v3.28.1]
❯ arm-none-eabi-nm --print-size --demangle --line-numbers libs/gps/CMakeFiles/ublox_gps_driver.dir/Src/u-blox_gnss_MAX-M10S.c.obj
00000000 00000001 b ublox_initialized  # 1 byte in RAM
00000110 b ubx_packet         # 272 bytes (0x110) in RAM

```
If any of you want to review my work the [API document](docs/drivers/max-m10s.md) is probably the best place to start. 

## Next Steps
Future improvements will focus on:
- Integration with APRS packet structure
- System-level error handling 
- Additional functionality based on integration requirements

I think these improvements will be addressed in separate PRs as we begin system integration.

