### PR TITLE
Adding error types to common lib

### DIFF
--- a/libs/common/Inc/error_types.h
+++ b/libs/common/Inc/error_types.h
@@ -1,0 +1,65 @@
+/****************************************************************************
+ * @file: error_types.h
+ * @brief: Common error handling system for PicoAPRS balloon platform
+ *
+ * Provides a unified error handling system for all components in the PicoAPRS
+ * platform. Error codes are 16-bit values that encode:
+ * - Whether the error is fatal
+ * - Which subsystem generated the error
+ * - Component-specific error code
+ *
+ * @note: Each subsystem should define its own specific error codes using the
+ *       provided MAKE_ERROR macro.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+// Subsystem identifiers (bits 14-8, leaving MSB for fatal flag)
+#define ERR_SUBSYSTEM_COMMON  0x00
+#define ERR_SUBSYSTEM_GPS     0x01
+#define ERR_SUBSYSTEM_RADIO   0x02
+#define ERR_SUBSYSTEM_SENSORS 0x03
+#define ERR_SUBSYSTEM_POWER   0x04
+// ...Add more subsystems as needed...
+
+// Masks for error code components
+#define ERR_FATAL_MASK        0x8000  // Bit 15
+#define ERR_SUBSYSTEM_MASK    0x7F00  // Bits 14-8
+#define ERR_COMPONENT_MASK    0x00FF  // Bits 7-0
+
+/**
+ * @brief Error code format for pico balloon system
+ *
+ * 16-bit error code format: 0xFSCC where:
+ * - F: Fatal flag (1 = fatal, 0 = non-fatal)
+ * - S: Subsystem ID (7 bits)
+ * - CC: Component-specific error code (8 bits)
+ *
+ * Example: 0x8102 = Fatal GPS error 02
+ */
+
+// Success code only - all other errors defined by specific components
+#define ERR_OK 0x0000
+
+// Helper Functions
+static inline bool IS_ERROR_FATAL(uint16_t error) {
+    return (error & ERR_FATAL_MASK) != 0;
+}
+
+static inline uint8_t GET_ERROR_SUBSYSTEM(uint16_t error) {
+    return (error & ERR_SUBSYSTEM_MASK) >> 8;
+}
+
+static inline uint8_t GET_ERROR_COMPONENT(uint16_t error) {
+    return error & ERR_COMPONENT_MASK;
+}
+
+static inline uint16_t MAKE_ERROR(uint8_t subsystem, uint8_t component, bool fatal) {
+    return (fatal ? ERR_FATAL_MASK : 0) |
+           ((subsystem & 0x7F) << 8) |
+           (component & 0xFF);
+}

--- a/libs/common/Inc/error_types.h
+++ b/libs/common/Inc/error_types.h
@@ -60,6 +60,6 @@ static inline uint8_t GET_ERROR_COMPONENT(uint16_t error) {
 
 static inline uint16_t MAKE_ERROR(uint8_t subsystem, uint8_t component, bool fatal) {
     return (fatal ? ERR_FATAL_MASK : 0) |
-           ((subsystem & 0x7F) << 8) |
-           (component & 0xFF);
+           ((subsystem & ERR_SUBSYSTEM_MASK) << 8) |
+           (component & ERR_COMPONENT_MASK);
 }


### PR DESCRIPTION
Please take a look at the added file for my comments on this PR. Hepler functions are `inline` to reduce function call overhead and should help performance. I'm not sure this is a perfect solution but can at least get us all on the same page for error handling. 

As an example of how to use this system, you could define errors like this for my GPS module:

```
#include error_types.h 

typedef enum {
    // Non-fatal GPS errors
    GPS_ERR_NO_FIX = MAKE_ERROR(ERR_SUBSYSTEM_GPS, 0x01, false),                    // No GPS fix available
    GPS_ERR_BAD_CHECKSUM = MAKE_ERROR(ERR_SUBSYSTEM_GPS, 0x02, false),    // Packet checksum failed
    GPS_ERR_NO_SATELLITES = MAKE_ERROR(ERR_SUBSYSTEM_GPS, 0x03, false),      // No satellites visible
    
    // Fatal GPS errors
    GPS_ERR_FATAL_INIT = MAKE_ERROR(ERR_SUBSYSTEM_GPS, 0x01, true),             // Init failed
    GPS_ERR_FATAL_I2C = MAKE_ERROR(ERR_SUBSYSTEM_GPS, 0x02, true)              // I2C bus error
} gps_error_t;
```