### PR TITLE
Add delay function and update test code output

### DIFF
--- a/libs/bme68x/CMakeLists.txt
+++ b/libs/bme68x/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(bme68x STATIC
 )
 
 target_compile_definitions(bme68x PUBLIC
+    BME68X_DO_NOT_USE_FPU
     $<$<CONFIG:Debug>:DEBUG>
 )
 

--- a/libs/bme68x/Inc/bme68x_driver.h
+++ b/libs/bme68x/Inc/bme68x_driver.h
@@ -23,17 +23,14 @@
  * @todo: Alternatively, we could include an "i2c.h" file under the assumption that one will be created within the application code.
  */
 #include "stm32l4xx_hal_i2c.h"
-
-/* ========================== MACROS ========================== */
-
-/**
- * @brief Used fixed point in the Bosch library
- * @todo: This can be removed when / if the Bosch library is reduced to only the necessary functionality
+/** @note: As currently written, the Bosch library needs BME68X_DO_NOT_USE_FPU
+ * to be set in order to prevent floating point code from being used. This is currently
+ * set in the CMakeLists.txt file for this driver.
  */
-#define BME68X_DO_NOT_USE_FPU
-
 #include "bme68x_defs.h"
 #include "bme68x.h"
+
+/* ========================== MACROS ========================== */
 
 /**
  * @brief Basic error macro

--- a/libs/bme68x/Inc/bme68x_driver.h
+++ b/libs/bme68x/Inc/bme68x_driver.h
@@ -69,6 +69,12 @@ typedef struct
 
   /** Structure to store sensor measurement data. */
   /** @todo: May modify this to be an array in order to support parallel mode */
+  /** @note: Since we're not using floating point, the data will be as follows:
+   *  - Temperature in degrees celsius x100
+   *  - Pressure in Pascal
+   *  - Humidity in % relative humidity x1000
+   *  - Gas resistance in Ohms
+   */
   struct bme68x_data sensor_data;
 
   // /** Array to store multiple sensor data values (for parallel mode). */

--- a/libs/bme68x/Src/bme68x_driver.c
+++ b/libs/bme68x/Src/bme68x_driver.c
@@ -137,7 +137,7 @@ uint8_t bme_fetch_data(bme68x_sensor_t *bme)
 /** Get the measurement duration in microseconds*/
 uint32_t bme_get_meas_dur(bme68x_sensor_t *bme, uint8_t opmode)
 {
-  if (opmode == NULL || opmode == BME68X_SLEEP_MODE)
+  if (opmode == BME68X_SLEEP_MODE)
     opmode = bme->last_opmode;
 
   return bme68x_get_meas_dur(opmode, &bme->conf, &bme->device);

--- a/libs/bme68x/Src/bme68x_driver.c
+++ b/libs/bme68x/Src/bme68x_driver.c
@@ -150,6 +150,12 @@ void bme_delay_us(uint32_t period_us, void *intf_ptr)
   // so cast to void to avoid compiler warning
   (void)intf_ptr;
   /** @todo: Implement a microsecond delay here, possibly with a DWT cycle counter, or an actual hardware timer */
+  // FIXME: Short-term implementation of a blocking delay
+  volatile uint32_t cycles = period_us * 20;
+  while (cycles--)
+  {
+    __NOP();
+  }
 }
 
 /** Implements the default microsecond delay callback */

--- a/tests/test_bme688/test_bme688.c
+++ b/tests/test_bme688/test_bme688.c
@@ -133,7 +133,6 @@ int main(void)
   // bme_read(0xD0, &sensor_id, 4, &hi2c1);
   // debug_print("Received sensor ID: 0x%X\r\n", sensor_id);
 
-  debug_print("Temperature(deg C), Pressure(Pa), Humidity(%), Gas resistance(ohm), Status\r\n");
   /* USER CODE END 2 */
 
   /* Infinite loop */
@@ -148,11 +147,17 @@ int main(void)
     int fetch_success = bme_fetch_data(&bme);
     if (fetch_success)
     {
-      debug_print("%d, ", bme.sensor_data.temperature);
-      debug_print("%d, ", bme.sensor_data.pressure);
-      debug_print("%d, ", bme.sensor_data.humidity);
-      debug_print("%d, ", bme.sensor_data.gas_resistance);
-      debug_print("%X, \r\n", bme.sensor_data.status);
+      debug_print("Temperature: %d.%02d°C, ",
+                  bme.sensor_data.temperature / 100,
+                  (bme.sensor_data.temperature % 100));
+      debug_print("Pressure: %d Pa, ", bme.sensor_data.pressure);
+      debug_print("Humidity: %d.%03d%%, ",
+                  bme.sensor_data.humidity / 1000,
+                  (bme.sensor_data.humidity % 1000));
+      debug_print("Gas Resistance: %d.%03d kΩ, ",
+                  bme.sensor_data.gas_resistance / 1000,
+                  (bme.sensor_data.gas_resistance % 1000));
+      debug_print("Status: 0x%X\r\n", bme.sensor_data.status);
     }
 
     // The "blink" code is a simple verification of program execution,


### PR DESCRIPTION
This set of changes allows the test application to correctly retrieve and display data from the sensor. Includes the following:
- Adds a basic blocking delay for prototyping purposes
- Fixes the `define` used to prevent floating point code from being added by the Bosch library
- Updates test application to correctly display

Closes #21 

**Note:** Retrieved data appears to be correct, with the possible exception of the humidity data. This is returning 100% humidity, so additional investigation should be done in #23