### PR TITLE
Trim bosch library

### DIFF
--- a/libs/bme68x/Inc/bme68x.h
+++ b/libs/bme68x/Inc/bme68x.h
@@ -238,7 +238,7 @@ extern "C"
    * \code
    * int8_t bme68x_set_conf(struct bme68x_conf *conf, struct bme68x_dev *dev);
    * \endcode
-   * @details This API is used to set the oversampling, filter and odr configuration
+   * @details This API is used to set the oversampling and filter configuration
    *
    * @param[in] conf    : Desired sensor configuration.
    * @param[in,out] dev : Structure instance of bme68x_dev.
@@ -255,8 +255,7 @@ extern "C"
    * \code
    * int8_t bme68x_get_conf(struct bme68x_conf *conf, struct bme68x_dev *dev);
    * \endcode
-   * @details This API is used to get the oversampling, filter and odr
-   * configuration
+   * @details This API is used to get the oversampling and filter configuration
    *
    * @param[out] conf   : Present sensor configuration.
    * @param[in,out] dev : Structure instance of bme68x_dev.

--- a/libs/bme68x/Inc/bme68x_defs.h
+++ b/libs/bme68x/Inc/bme68x_defs.h
@@ -299,9 +299,6 @@
 /* Forced operation mode */
 #define BME68X_FORCED_MODE UINT8_C(1)
 
-/* Parallel operation mode */
-#define BME68X_PARALLEL_MODE UINT8_C(2)
-
 /* Sequential operation mode */
 #define BME68X_SEQUENTIAL_MODE UINT8_C(3)
 
@@ -877,12 +874,6 @@ struct bme68x_heatr_conf
 
   /*! Variable to store the length of the heating profile */
   uint8_t profile_len;
-
-  /*!
-   * Variable to store heating duration for parallel mode
-   * in milliseconds
-   */
-  uint16_t shared_heatr_dur;
 };
 
 /*

--- a/libs/bme68x/Inc/bme68x_defs.h
+++ b/libs/bme68x/Inc/bme68x_defs.h
@@ -262,35 +262,6 @@
 /* Filter coefficient of 128 */
 #define BME68X_FILTER_SIZE_127 UINT8_C(7)
 
-/* ODR/Standby time macros */
-
-/* Standby time of 0.59ms */
-#define BME68X_ODR_0_59_MS UINT8_C(0)
-
-/* Standby time of 62.5ms */
-#define BME68X_ODR_62_5_MS UINT8_C(1)
-
-/* Standby time of 125ms */
-#define BME68X_ODR_125_MS UINT8_C(2)
-
-/* Standby time of 250ms */
-#define BME68X_ODR_250_MS UINT8_C(3)
-
-/* Standby time of 500ms */
-#define BME68X_ODR_500_MS UINT8_C(4)
-
-/* Standby time of 1s */
-#define BME68X_ODR_1000_MS UINT8_C(5)
-
-/* Standby time of 10ms */
-#define BME68X_ODR_10_MS UINT8_C(6)
-
-/* Standby time of 20ms */
-#define BME68X_ODR_20_MS UINT8_C(7)
-
-/* No standby time */
-#define BME68X_ODR_NONE UINT8_C(8)
-
 /* Operating mode macros */
 
 /* Sleep operation mode */
@@ -298,9 +269,6 @@
 
 /* Forced operation mode */
 #define BME68X_FORCED_MODE UINT8_C(1)
-
-/* Sequential operation mode */
-#define BME68X_SEQUENTIAL_MODE UINT8_C(3)
 
 /* Coefficient index macros */
 
@@ -516,12 +484,6 @@
 /* Mask for IIR filter */
 #define BME68X_FILTER_MSK UINT8_C(0X1c)
 
-/* Mask for ODR[3] */
-#define BME68X_ODR3_MSK UINT8_C(0x80)
-
-/* Mask for ODR[2:0] */
-#define BME68X_ODR20_MSK UINT8_C(0xe0)
-
 /* Mask for temperature oversampling */
 #define BME68X_OST_MSK UINT8_C(0Xe0)
 
@@ -574,12 +536,6 @@
 
 /* Pressure oversampling bit position */
 #define BME68X_OSP_POS UINT8_C(2)
-
-/* ODR[3] bit position */
-#define BME68X_ODR3_POS UINT8_C(7)
-
-/* ODR[2:0] bit position */
-#define BME68X_ODR20_POS UINT8_C(5)
 
 /* Run gas bit position */
 #define BME68X_RUN_GAS_POS UINT8_C(4)
@@ -828,7 +784,7 @@ struct bme68x_calib_data
 };
 
 /*
- * @brief BME68X sensor settings structure which comprises of ODR,
+ * @brief BME68X sensor settings structure which comprises of
  * over-sampling and filter settings.
  */
 struct bme68x_conf
@@ -844,12 +800,6 @@ struct bme68x_conf
 
   /*! Filter coefficient. Refer @ref filter*/
   uint8_t filter;
-
-  /*!
-   * Standby time between sequential mode measurement profiles.
-   * Refer @ref odr
-   */
-  uint8_t odr;
 };
 
 /*

--- a/libs/bme68x/Inc/bme68x_defs.h
+++ b/libs/bme68x/Inc/bme68x_defs.h
@@ -305,14 +305,6 @@
 /* Sequential operation mode */
 #define BME68X_SEQUENTIAL_MODE UINT8_C(3)
 
-/* SPI page macros */
-
-/* SPI memory page 0 */
-#define BME68X_MEM_PAGE0 UINT8_C(0x10)
-
-/* SPI memory page 1 */
-#define BME68X_MEM_PAGE1 UINT8_C(0x00)
-
 /* Coefficient index macros */
 
 /* Length for all coefficients */
@@ -572,15 +564,6 @@
 /* Mask for heater stability */
 #define BME68X_HEAT_STAB_MSK UINT8_C(0x10)
 
-/* Mask for SPI memory page */
-#define BME68X_MEM_PAGE_MSK UINT8_C(0x10)
-
-/* Mask for reading a register in SPI */
-#define BME68X_SPI_RD_MSK UINT8_C(0x80)
-
-/* Mask for writing a register in SPI */
-#define BME68X_SPI_WR_MSK UINT8_C(0x7f)
-
 /* Mask for the H1 calibration coefficient */
 #define BME68X_BIT_H1_DATA_MSK UINT8_C(0x0f)
 
@@ -699,17 +682,6 @@ typedef void (*bme68x_delay_us_fptr_t)(uint32_t period, void *intf_ptr);
  * @param[in,out] reg_data: Data array to read/write
  * @param[in] len: Length of the data array
  */
-
-/*
- * @brief Interface selection Enumerations
- */
-enum bme68x_intf
-{
-  /*! SPI interface */
-  BME68X_SPI_INTF,
-  /*! I2C interface */
-  BME68X_I2C_INTF
-};
 
 /* Structure definitions */
 
@@ -939,9 +911,6 @@ struct bme68x_dev
    * ----------------------------------------
    */
   uint32_t variant_id;
-
-  /*! SPI/I2C interface */
-  enum bme68x_intf intf;
 
   /*! Memory page used */
   uint8_t mem_page;

--- a/libs/bme68x/Inc/bme68x_driver.h
+++ b/libs/bme68x/Inc/bme68x_driver.h
@@ -68,7 +68,6 @@ typedef struct
   struct bme68x_heatr_conf heatr_conf;
 
   /** Structure to store sensor measurement data. */
-  /** @todo: May modify this to be an array in order to support parallel mode */
   /** @note: Since we're not using floating point, the data will be as follows:
    *  - Temperature in degrees celsius x100
    *  - Pressure in Pascal
@@ -76,16 +75,6 @@ typedef struct
    *  - Gas resistance in Ohms
    */
   struct bme68x_data sensor_data;
-
-  // /** Array to store multiple sensor data values (for parallel mode). */
-  // struct bme68x_data sensor_data[3];
-
-  /** @todo: Similar to a sensor_data array, n_fields and i_fields are for parallel mode support */
-  // /** Number of data fields in parallel mode. */
-  // uint8_t n_fields;
-
-  // /** Index for tracking sensor data fields. */
-  // uint8_t i_fields;
 
   /** Last operation mode used by the sensor. */
   uint8_t last_opmode;
@@ -146,22 +135,18 @@ void bme_set_TPH(bme68x_sensor_t *bme, uint8_t os_temp, uint8_t os_pres, uint8_t
  * @param[in] bme Pointer to bme68x sensor interface
  * @param[in] temp Heater temperature in degree Celsius
  * @param[in] dur Heating duration in milliseconds
- * @todo: Implement similar functions for sequential and parallel modes, as needed.
  */
 void bme_set_heaterprof(bme68x_sensor_t *bme, uint16_t temp, uint16_t dur);
 
 /**
  * @brief Set the operation mode
  *
- * Set the desired operation mode.
- * @todo: Initially, we will only support forced mode, which performs a single measurement
- * and allows for automatically returning to sleep mode. The gas sensor heater only operates
- * during measurement in this mode.
- * In parallel mode, multiple TPHG cycles are performed, the sensor does not return to sleep
- * mode automatically, and the gas sensor heater operates in parallel to TPH measurement.
+ * Set the desired operation mode. Currently supports sleep mode and forced mode for
+ * a single, low-power measurment which may automatically return to sleep mode.
+ * The gas sensor heater only operates during measurement in this mode.
  *
  * @param[in] bme Pointer to bme68x sensor interface
- * @param[in] opmode BME68X_SLEEP_MODE, BME68X_FORCED_MODE, BME68X_PARALLEL_MODE, BME68X_SEQUENTIAL_MODE
+ * @param[in] opmode BME68X_SLEEP_MODE, BME68X_FORCED_MODE
  */
 void bme_set_opmode(bme68x_sensor_t *bme, uint8_t opmode);
 
@@ -178,32 +163,11 @@ void bme_set_opmode(bme68x_sensor_t *bme, uint8_t opmode);
 uint8_t bme_fetch_data(bme68x_sensor_t *bme);
 
 /**
- * @brief Get a single data field
- *
- * @todo: Implement as needed
- *
- * @param[in] bme Pointer to bme68x sensor interface
- * @param[out] data Structure where the data is to be stored
- * @return Number of new fields remaining
- */
-// uint8_t bme_get_data(bme68x_sensor_t *bme, bme68x_data &data);
-
-/**
- * @brief Function to get whole sensor data
- *
- * @todo: Implement as needed
- *
- * @param[in] bme Pointer to bme68x sensor interface
- * @return Sensor data
- */
-// bme68x_data *bme_get_alldata(bme68x_sensor_t *bme);
-
-/**
  * @brief Get the measurement duration in microseconds
  *
  * Calls bme68x_get_meas_dur, which calculates the total measurement duration
  * based on the total number of samples to be taken, as determined by the oversampling
- * for each value; if not operating in parallel mode, a wake-up duration of 1ms is added.
+ * for each value; a wake-up duration of 1ms is added.
  *
  * @param[in] bme Pointer to bme68x sensor interface
  * @param[in] opmode Operation mode of the sensor. Attempts to use the last one if nothing is set

--- a/libs/bme68x/Inc/bme68x_driver.h
+++ b/libs/bme68x/Inc/bme68x_driver.h
@@ -233,14 +233,16 @@ int8_t bme_read(uint8_t reg_addr, uint8_t *reg_data, uint32_t length, void *intf
  *     while (1)
  *     {
  *         bme_set_opmode(&bme, BME68X_FORCED_MODE);
+ *         // @todo: May adjust the specific timing function called here, but it should be based on bme_get_meas_dur
+ *         bme_delay_us(bme_get_meas_dur(&bme, BME68X_SLEEP_MODE), &hi2c1);
  *         int fetch_success = bme_fetch_data(&bme);
  *         if (fetch_success) {
-             debug_print("%d, ", bme.sensor_data.temperature);
-             debug_print("%d, ", bme.sensor_data.pressure);
-             debug_print("%d, ", bme.sensor_data.humidity);
-             debug_print("%d, ", bme.sensor_data.gas_resistance);
-             debug_print("%X, \r\n", bme.sensor_data.status);
-           }
+ *           debug_print("%d, ", bme.sensor_data.temperature);
+ *           debug_print("%d, ", bme.sensor_data.pressure);
+ *           debug_print("%d, ", bme.sensor_data.humidity);
+ *           debug_print("%d, ", bme.sensor_data.gas_resistance);
+ *           debug_print("%X, \r\n", bme.sensor_data.status);
+ *         }
  *     }
  * }
  * @endcode

--- a/libs/bme68x/Src/bme68x.c
+++ b/libs/bme68x/Src/bme68x.c
@@ -478,13 +478,7 @@ uint32_t bme68x_get_meas_dur(const uint8_t op_mode, struct bme68x_conf *conf, st
 int8_t bme68x_get_data(uint8_t op_mode, struct bme68x_data *data, uint8_t *n_data, struct bme68x_dev *dev)
 {
   int8_t rslt;
-  uint8_t i = 0, j = 0, new_fields = 0;
-  struct bme68x_data *field_ptr[3] = {0};
-  struct bme68x_data field_data[3] = {{0}};
-
-  field_ptr[0] = &field_data[0];
-  field_ptr[1] = &field_data[1];
-  field_ptr[2] = &field_data[2];
+  uint8_t new_fields = 0;
 
   rslt = null_ptr_check(dev);
   if ((rslt == BME68X_OK) && (data != NULL))
@@ -1306,10 +1300,7 @@ static int8_t null_ptr_check(const struct bme68x_dev *dev)
 static int8_t set_conf(const struct bme68x_heatr_conf *conf, uint8_t op_mode, uint8_t *nb_conv, struct bme68x_dev *dev)
 {
   int8_t rslt = BME68X_OK;
-  uint8_t i;
-  uint8_t shared_dur;
   uint8_t write_len = 0;
-  uint8_t heater_dur_shared_addr = BME68X_REG_SHD_HEATR_DUR;
   uint8_t rh_reg_addr[10] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
   uint8_t rh_reg_data[10] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
   uint8_t gw_reg_addr[10] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};

--- a/libs/bme68x/Src/bme68x.c
+++ b/libs/bme68x/Src/bme68x.c
@@ -96,12 +96,6 @@ static int8_t read_field_data(uint8_t index, struct bme68x_data *data, struct bm
 /* This internal API is used to read all data fields of the sensor */
 static int8_t read_all_field_data(struct bme68x_data *const data[], struct bme68x_dev *dev);
 
-/* This internal API is used to switch between SPI memory pages */
-static int8_t set_mem_page(uint8_t reg_addr, struct bme68x_dev *dev);
-
-/* This internal API is used to get the current SPI memory page */
-static int8_t get_mem_page(struct bme68x_dev *dev);
-
 /* This internal API is used to check the bme68x_dev for null pointers */
 static int8_t null_ptr_check(const struct bme68x_dev *dev);
 
@@ -191,17 +185,7 @@ int8_t bme68x_set_regs(const uint8_t *reg_addr, const uint8_t *reg_data, uint32_
       /* Interleave the 2 arrays */
       for (index = 0; index < len; index++)
       {
-        if (dev->intf == BME68X_SPI_INTF)
-        {
-          /* Set the memory page */
-          rslt = set_mem_page(reg_addr[index], dev);
-          tmp_buff[(2 * index)] = reg_addr[index] & BME68X_SPI_WR_MSK;
-        }
-        else
-        {
-          tmp_buff[(2 * index)] = reg_addr[index];
-        }
-
+        tmp_buff[(2 * index)] = reg_addr[index];
         tmp_buff[(2 * index) + 1] = reg_data[index];
       }
 
@@ -239,16 +223,6 @@ int8_t bme68x_get_regs(uint8_t reg_addr, uint8_t *reg_data, uint32_t len, struct
   rslt = null_ptr_check(dev);
   if ((rslt == BME68X_OK) && reg_data)
   {
-    if (dev->intf == BME68X_SPI_INTF)
-    {
-      /* Set the memory page */
-      rslt = set_mem_page(reg_addr, dev);
-      if (rslt == BME68X_OK)
-      {
-        reg_addr = reg_addr | BME68X_SPI_RD_MSK;
-      }
-    }
-
     dev->intf_rslt = dev->read(reg_addr, reg_data, len, dev->intf_ptr);
     if (dev->intf_rslt != 0)
     {
@@ -278,11 +252,6 @@ int8_t bme68x_soft_reset(struct bme68x_dev *dev)
   rslt = null_ptr_check(dev);
   if (rslt == BME68X_OK)
   {
-    if (dev->intf == BME68X_SPI_INTF)
-    {
-      rslt = get_mem_page(dev);
-    }
-
     /* Reset the device */
     if (rslt == BME68X_OK)
     {
@@ -292,12 +261,6 @@ int8_t bme68x_soft_reset(struct bme68x_dev *dev)
       {
         /* Wait for 5ms */
         dev->delay_us(BME68X_PERIOD_RESET, dev->intf_ptr);
-
-        /* After reset get the memory page */
-        if (dev->intf == BME68X_SPI_INTF)
-        {
-          rslt = get_mem_page(dev);
-        }
       }
     }
   }
@@ -742,7 +705,6 @@ int8_t bme68x_selftest_check(const struct bme68x_dev *dev)
     t_dev.amb_temp = 25;
     t_dev.read = dev->read;
     t_dev.write = dev->write;
-    t_dev.intf = dev->intf;
     t_dev.delay_us = dev->delay_us;
     t_dev.intf_ptr = dev->intf_ptr;
 
@@ -1355,75 +1317,6 @@ static int8_t read_all_field_data(struct bme68x_data *const data[], struct bme68
     else
     {
       data[i]->gas_resistance = calc_gas_resistance_low(adc_gas_res_low, gas_range_l, dev);
-    }
-  }
-
-  return rslt;
-}
-
-/* This internal API is used to switch between SPI memory pages */
-static int8_t set_mem_page(uint8_t reg_addr, struct bme68x_dev *dev)
-{
-  int8_t rslt;
-  uint8_t reg;
-  uint8_t mem_page;
-
-  /* Check for null pointers in the device structure*/
-  rslt = null_ptr_check(dev);
-  if (rslt == BME68X_OK)
-  {
-    if (reg_addr > 0x7f)
-    {
-      mem_page = BME68X_MEM_PAGE1;
-    }
-    else
-    {
-      mem_page = BME68X_MEM_PAGE0;
-    }
-
-    if (mem_page != dev->mem_page)
-    {
-      dev->mem_page = mem_page;
-      dev->intf_rslt = dev->read(BME68X_REG_MEM_PAGE | BME68X_SPI_RD_MSK, &reg, 1, dev->intf_ptr);
-      if (dev->intf_rslt != 0)
-      {
-        rslt = BME68X_E_COM_FAIL;
-      }
-
-      if (rslt == BME68X_OK)
-      {
-        reg = reg & (~BME68X_MEM_PAGE_MSK);
-        reg = reg | (dev->mem_page & BME68X_MEM_PAGE_MSK);
-        dev->intf_rslt = dev->write(BME68X_REG_MEM_PAGE & BME68X_SPI_WR_MSK, &reg, 1, dev->intf_ptr);
-        if (dev->intf_rslt != 0)
-        {
-          rslt = BME68X_E_COM_FAIL;
-        }
-      }
-    }
-  }
-
-  return rslt;
-}
-
-/* This internal API is used to get the current SPI memory page */
-static int8_t get_mem_page(struct bme68x_dev *dev)
-{
-  int8_t rslt;
-  uint8_t reg;
-
-  /* Check for null pointer in the device structure*/
-  rslt = null_ptr_check(dev);
-  if (rslt == BME68X_OK)
-  {
-    dev->intf_rslt = dev->read(BME68X_REG_MEM_PAGE | BME68X_SPI_RD_MSK, &reg, 1, dev->intf_ptr);
-    if (dev->intf_rslt != 0)
-    {
-      rslt = BME68X_E_COM_FAIL;
-    }
-    else
-    {
-      dev->mem_page = reg & BME68X_MEM_PAGE_MSK;
     }
   }
 

--- a/libs/bme68x/Src/bme68x_driver.c
+++ b/libs/bme68x/Src/bme68x_driver.c
@@ -38,9 +38,6 @@ void bme_init(bme68x_sensor_t *bme, I2C_HandleTypeDef *i2c_handle)
   bme->device.write = &bme_write;
   bme->device.delay_us = bme_delay_us;
   bme->status = BME68X_OK;
-  /** @todo If supporting parallel mode, initialize n_fields and i_fields on bme struct */
-  // bme->n_fields = 0;
-  // bme->i_fields = 0;
   // Typical ambient temperature in Celsius
   bme->device.amb_temp = 25;
   // Assume sensor starts in sleep mode
@@ -108,30 +105,10 @@ void bme_set_opmode(bme68x_sensor_t *bme, uint8_t opmode)
 /** Fetch data from the sensor into the struct's sensor_data buffer */
 uint8_t bme_fetch_data(bme68x_sensor_t *bme)
 {
-  /** @todo: For now, hardcoding the n_fields value to reflect usage of forced mode.
-   * This may be changed to reflect usage of alternate modes.
-   */
-  // bme->n_fields = 0;
   uint8_t n_fields = 0;
-  // bme->status = bme68x_get_data(bme->last_opmode, bme->sensor_data, &bme->n_fields, &bme->device);
   bme->status = bme68x_get_data(bme->last_opmode, &bme->sensor_data, &n_fields, &bme->device);
-  // bme->i_fields = 0;
-
-  // return bme->n_fields;
   return n_fields;
 }
-
-/** @todo: Implement bme_get_data as needed */
-/** Get a single data field */
-// uint8_t bme_get_data(bme68x_sensor_t *bme, bme68x_data &data) {
-
-// }
-
-/** @todo: Implement bme_get_alldata as needed */
-/** Get whole sensor data */
-// bme68x_data *bme_get_alldata(bme68x_sensor_t *bme) {
-
-// }
 
 /** Get the measurement duration in microseconds*/
 uint32_t bme_get_meas_dur(bme68x_sensor_t *bme, uint8_t opmode)

--- a/libs/bme68x/Src/bme68x_driver.c
+++ b/libs/bme68x/Src/bme68x_driver.c
@@ -32,7 +32,6 @@ void bme_init(bme68x_sensor_t *bme, I2C_HandleTypeDef *i2c_handle)
   //
   // Set default values
   //
-  bme->device.intf = BME68X_I2C_INTF;
   bme->device.intf_ptr = i2c_handle;
   /** @todo (maybe) Assign variant ID on bme struct */
   bme->device.read = &bme_read;

--- a/libs/bme68x/bme68x.md
+++ b/libs/bme68x/bme68x.md
@@ -1,0 +1,219 @@
+# Bosch BME68x Driver
+
+## Overview
+
+This driver is used to initialize and configure a Bosch 68x sensor (specifically the [688](https://www.bosch-sensortec.com/products/environmental-sensors/gas-sensors/bme688/) or [680](https://www.bosch-sensortec.com/products/environmental-sensors/gas-sensors/bme680/)), and retrieve data for temperature, pressure, humidity, and a resistance value reflecting gas composition. Communication with the sensor takes place over I2C, using an I2C handle created with the STM32 HAL.
+
+Driver functionality is focused on low-power environments with minimal code storage. There may be features supported by the 688, for example, that are not supported here because they have requirements that are outside the anticipated operating context for the Pico Balloon platform.
+
+### Driver Structure
+
+The driver is based on a combination of a library provided by Bosch with a simplified interface using the STM32 HAL. The files containing code from Bosch include `bme68x_def.h`, `bme68x.h`, and `bme68x.c`. The STM32 HAL support and simplified interface is contained in `bme68x_driver.h` and `bme68x_driver.c`.
+
+The Bosch code was retrieved from the [Bosch-BME68x-Library github repo](https://github.com/boschsensortec/Bosch-BME68x-Library/tree/master) and checked into this repository in whole. The library was then reduced to support only the necessary functionality. See the [Design Decisions](#design-decisions) below for additional detail.
+
+In addition, the Bosch library github repo contained an Arduino library written in C++. This served as a model for many of the functions provided in this driver, with appropriate modifications made for the STM32.
+
+### Example Usage
+
+The following example shows creation and initialization of a `bme68x_sensor_t` struct, which contains a pointer to an I2C handle previously initialized in application code. The struct also contains status, a BME68x device struct, configuration, sensor data, and the last operation mode.
+
+After initialization, configuration is performed, using default oversampling values for the temperature, pressure, and humidity measurements, and a heater configuration of 300 deg C for 100ms in forced mode.
+
+Data is then fetched from the sensor repeatedly in a loop. The specific delay function may be adjusted to use a hardware timer, but the microsecond delay should still be based on the return value from the `bme_get_meas_dur` function.
+
+```c
+#include "bme68x_driver.h"
+
+int main(void) {
+  bme68x_sensor_t bme;
+  bme_init(&bme, &hi2c1);
+  bme_set_TPH_default(&bme);
+  bme_set_heaterprof(&bme, 300, 100);
+
+  while (1)
+  {
+    bme_set_opmode(&bme, BME68X_FORCED_MODE);
+    /** @todo: May adjust the specific timing function called here, but it should be based on bme_get_meas_dur */
+    bme_delay_us(bme_get_meas_dur(&bme, BME68X_SLEEP_MODE), &hi2c1);
+    int fetch_success = bme_fetch_data(&bme);
+    if (fetch_success) {
+          debug_print("%d, ", bme.sensor_data.temperature);
+          debug_print("%d, ", bme.sensor_data.pressure);
+          debug_print("%d, ", bme.sensor_data.humidity);
+          debug_print("%d, ", bme.sensor_data.gas_resistance);
+          debug_print("%X, \r\n", bme.sensor_data.status);
+        }
+  }
+}
+
+```
+
+## Driver API
+
+### `bme68x_sensor_t` struct
+
+Structure to store necessary configuration and data to interact with the sensor over I2C. Contains as members the structs `bme68x_dev`, `bme68x_conf`, `bme68x_heatr_conf`, and `bme68x_data`, which are defined in `bme68x_defs.h`. Also contains an `I2C_HandleTypeDef` pointer to allow I2C communication using STM32 HAL I2C functions.
+
+### `bme_init()`
+
+Configures the sensor with default settings.
+
+**Parameters:**
+- `bme`: Pointer to newly initialized bme68x sensor interface
+- `i2c_handle`: Pointer to I2C handle
+
+### `bme_check_status()`
+
+Checks and returns current bme instance status. Returns 0 for status OK, 1 for warning, -1 for error. **NOTE**: This may be modified in the future to leverage the common error type construction defined in [libs/common/Inc/error_types.h](../common/Inc/error_types.h).
+
+**Parameters:**
+- `bme`: Pointer to bme68x sensor interface
+
+**Returns:**
+- `int8_t`: 0 for status 0, 1 for warning, -1 for error
+
+### `bme_set_TPH_default()`
+
+Set the Temperature, Pressure and Humidity over-sampling using the following defaults: 2 samples for temperature, 16 for pressure, 1 for humidity. These defaults are based on those used in the self-test check function provided in the Bosch library.
+
+**Parameters:**
+- `bme`: Pointer to bme68x sensor interface
+
+### `bme_set_TPH()`
+
+Set the Temperature, Pressure and Humidity over-sampling.
+
+**Parameters:**
+- `bme`: Pointer to bme68x sensor interface
+- `os_temp`: Number of temperature measurements to perform, BME68X_OS_NONE to BME68X_OS_16X
+- `os_pres`: Number of pressure measurements to perform, BME68X_OS_NONE to BME68X_OS_16X
+- `os_hum`: Number of humidity measurements to perform, BME68X_OS_NONE to BME68X_OS_16X
+
+### `bme_set_heaterprof()`
+
+Set the heater profile for Forced mode. Parameters for temperature and duration may be adjusted depending on the gas profile being targeted.
+
+**Parameters:**
+- `bme`: Pointer to bme68x sensor interface
+- `temp`: Heater temperature in degree Celsius
+- `dur`: Heating duration in milliseconds
+
+### `bme_set_opmode()`
+
+Set the operation mode. Currently supports sleep mode and forced mode for a single, low-power measurment which may automatically return to sleep mode. The gas sensor heater only operates during measurement in this mode.
+
+**Parameters:**
+- `bme`: Pointer to bme68x sensor interface
+- `opmode`: BME68X_SLEEP_MODE or BME68X_FORCED_MODE
+
+### `bme_fetch_data()`
+
+Fetch data from the sensor into the struct's sensor_data buffer. **NOTE**: This should typically return 1, indicating new data was retrieved. This value could be more than 1 when implementing support for parallel or sequential data retrieval modes.
+
+**Parameters:**
+- `bme`: Pointer to bme68x sensor interface
+
+**Returns:**
+- `uint8_t`: Number of new data fields
+
+### `bme_get_meas_dur()`
+
+Get the measurement duration in microseconds. This is the total measurement duration based on the total number of samples to be taken, as determined by the oversampling for each value.
+
+**Parameters:**
+- `bme`: Pointer to bme68x sensor interface
+- `opmode`: Operation mode of the sensor. Attempts to use the last one if nothing is set
+
+**Returns:**
+- `uint32_t`: Measurement duration in microseconds
+
+### `bme_delay_us()`
+
+Implements the default microsecond delay callback, as called from the Bosch library. **NOTE**: This function signature is currently determined by the original one used by the Bosch library developers. We may wish to modify it in the future to better accommodate our usage of the STM32 HAL timing functions.
+
+**Parameters:**
+- `period_us`: Duration of the delay in microseconds
+- `intf_ptr`: Pointer to the interface descriptor for I2C
+
+### `bme_write()`
+
+Implements the default I2C write transaction. This is leveraged by the Bosch library to perform writes to the device over I2C. It should typically not be necessary for application code to call this function directly, though it may be useful in troubleshooting.
+
+**Parameters:**
+- `reg_addr`: Register address of the sensor
+- `reg_data`: Pointer to the data to be written to the sensor
+- `length`: Length of the transfer
+- `i2c_handle`: Pointer to the stm32 I2C peripheral handle
+
+**Returns:**
+- `int8_t`: 0 if successful, non-zero otherwise
+
+### `bme_read()`
+
+Implements the default I2C read transaction. This is leveraged by the Bosch library to perform reads from the device over I2C. It should typically not be necessary for application code to call this function directly, though it may be useful in troubleshooting.
+
+**Parameters:**
+- `reg_addr`: Register address of the sensor
+- `reg_data`: Pointer to the data to write the sensor value(s) to
+- `length`: Length of the transfer
+- `i2c_handle`: Pointer to the stm32 I2C peripheral handle
+
+**Returns:**
+- `int8_t`: 0 if successful, non-zero otherwise
+
+## Design Decisions
+
+As noted above in the overview, some functionality has been removed from the Bosch-provided library. This was based on expected operating conditions, considering factors such as power usage and flash storage. Below is an outline of functionality that was removed from the Bosch library, as well as functionality that was left in place, with brief explanations for each.
+
+The entirety of the Bosch library has been checked in to our codebase, so retrieving and re-implementing removed features in the future should be possible if desired.
+
+### Removed functionality
+
+**Parallel and sequential modes**
+
+Parallel mode is not supported by the BME680, and in the case of the 688, it is described as requiring more power than forced mode. Parallel mode also does not support automatically returning to sleep mode. In addition, the greatest benefit from parallel mode is likely achieved by using the AI training features possible with the 688. These features require usage of a static library provied by Bosch. At the current time, it is assumed that we should prioritize a smaller library size over utilizing this feature.
+
+Sequential mode is not documented in the 688 datasheet, but it seems likely this is also intended to be leveraged along with the AI training on targeting specific gas profiles. It allows for including multiple temperature and duration settings to be used for sequential measurements.
+
+**SPI support**
+
+We do not currently intend to support the SPI protocol for communication with sensors.
+
+### Maintained functionality
+
+**Conditional compilation for a kernel context**
+
+The `bme68x_defs.h` file provided by Bosch includes some conditional compilation sections (e.g. `#ifdef __KERNEL__`) which seem to be aimed at supporting usage of the library within a Linux kernel context. These have been left in place to allow for the possibility of RTOS usage in the future.
+
+**Conditional compilation for hardware floating point support**
+
+It is not necessarily anticipated that we will use floating point hardware, but the Bosch driver includes support for it. As with the above conditional compilation for a kernel context, this code does not contribute to the overall driver size as long as compilation correctly includes the `BME68X_DO_NOT_USE_FPU` definition. This is currently added in the `CMakeLists.txt` file for the driver.
+
+**Currently unused functions**
+
+There are a few functions from the Bosch library that are not currently in use, but could possibly be useful in the future (e.g. `sort_sensor_data`, `calc_heatr_dur_shared`, and `read_all_field_data`). These have been left in place under the assumption that the application will be compiled with some reasonable level of optimization which will result in their removal from the compiled binary.
+
+## Next Steps
+
+**Update delay function**
+
+The current delay function was added to allow for retrieval of data in a prototyping context. It should be replaced, probably with a hardware timer. Usage of the `HAL_Delay` function was attempted, but that function provides millisecond delays, rather that the microsecond delays required by this driver.
+
+Other alternatives might be using the DWT as a cycle counter, or modifying the Bosch library callback signature to be more specific to our needs.
+
+**Validate humidity measurements**
+
+The humidity measurements currently appear to be returning the max value consistently. This may be the result of the above prototyping-level delay function, or possibly an individual sensor-specific problem. First steps to resolve are to update the above delay function, test on additional sensors, and adjust the oversampling setting.
+
+**Create non-blocking version**
+
+We should allow for the driver to be used in a non-blocking manner, leveraging interrupts.
+
+**Ensure compatibility with an RTOS**
+
+This work is TBD, but the maintenance of the conditional compilation for the Linux kernel supports this work.
+
+**Use standardized error types**
+
+We should incorporate the common platform error types (see [libs/common/Inc/error_types.h](../common/Inc/error_types.h)). Specific functions where the standardized error types may be helpful include `bme_write`, `bme_read`, and `bme_check_status`.

--- a/tests/test_bme688/test_bme688.c
+++ b/tests/test_bme688/test_bme688.c
@@ -142,7 +142,8 @@ int main(void)
     /* USER CODE END WHILE */
     // Set to forced mode, which takes a single sample and returns to sleep mode
     bme_set_opmode(&bme, BME68X_FORCED_MODE);
-    /** @todo: Add a delay here for bme_get_meas_dur(&bme, BME68X_SLEEP_MODE) microseconds*/
+    /** @todo: May adjust the specific timing function called here, but it should be based on bme_get_meas_dur */
+    bme_delay_us(bme_get_meas_dur(&bme, BME68X_SLEEP_MODE), &hi2c1);
     // Fetch data
     int fetch_success = bme_fetch_data(&bme);
     if (fetch_success)


### PR DESCRIPTION
Removes code from the Bosch library that is not anticipated to be needed. This PR attempts the removal of features in a commit-by-commit fashion, in order to make it relatively straightforward to add the functionality back in if desired in the future.

This PR also adds documentation for the driver, including an overview of design decisions and next steps.

With the output below, an estimated total 5.3KiB of flash will be used for the BME68x driver code. If I'm understanding correctly, the RAM usage should be minimal, given that there are no global or static variables as indicated by nothing in the `data` and `bss` columns. The Bosch library code alone (`bme68x.c.obj`) was initially over 11KiB, so these changes represent a significant reduction in size.

More could still be removed, particular from the Bosch library, but it may make sense to start here and see if it's necessary.

```sh
$ arm-none-eabi-size build/Release/libs/bme68x/CMakeFiles/bme68x.dir/Src/bme68x.c.obj
   text    data     bss     dec     hex filename
   4862       0       0    4862    12fe build/Release/libs/bme68x/CMakeFiles/bme68x.dir/Src/bme68x.c.obj

$ arm-none-eabi-nm --print-size --demangle --line-numbers build/Release/libs/bme68x/CMakeFiles/bme68x.dir/Src/bme68x.c.obj
         U __aeabi_ldivmod      bme68x.c:0
00000000 00000070 T bme68x_get_conf
00000000 000004f8 T bme68x_get_data
00000000 0000015a T bme68x_get_heatr_conf
00000000 000000e8 T bme68x_get_meas_dur
00000000 0000004a T bme68x_get_op_mode
00000000 00000032 T bme68x_get_regs
00000000 000001e2 T bme68x_init
00000000 000001f0 T bme68x_selftest_check
00000000 0000021e T bme68x_set_conf
00000000 00000210 T bme68x_set_heatr_conf
00000000 000000a8 T bme68x_set_op_mode
00000000 000000fc T bme68x_set_regs
00000000 00000050 t bme68x_set_regs.constprop.0
00000000 00000048 T bme68x_soft_reset
         U memset       bme68x.c:0

$ arm-none-eabi-size build/Release/libs/bme68x/CMakeFiles/bme68x.dir/Src/bme68x_driver.c.obj
   text    data     bss     dec     hex filename
    548       0       0     548     224 build/Release/libs/bme68x/CMakeFiles/bme68x.dir/Src/bme68x_driver.c.obj
$ arm-none-eabi-nm --print-size --demangle --line-numbers build/Release/libs/bme68x/CMakeFiles/bme68x.dir/Src/bme68x_driver.c.obj
         U bme68x_get_conf      bme68x_driver.c:0
         U bme68x_get_data      bme68x_driver.c:0
         U bme68x_get_meas_dur  bme68x_driver.c:0
         U bme68x_init  bme68x_driver.c:0
         U bme68x_set_conf      bme68x_driver.c:0
         U bme68x_set_heatr_conf        bme68x_driver.c:0
         U bme68x_set_op_mode   bme68x_driver.c:0
00000000 00000016 T bme_check_status
00000000 00000022 T bme_delay_us
00000000 0000002a T bme_fetch_data
00000000 00000016 T bme_get_meas_dur
00000000 00000040 T bme_init
00000000 00000042 T bme_read
00000000 00000022 T bme_set_heaterprof
00000000 0000001c T bme_set_opmode
00000000 0000003e T bme_set_TPH
00000000 00000034 T bme_set_TPH_default
00000000 0000006c T bme_write
         U HAL_I2C_Master_Receive       bme68x_driver.c:0
         U HAL_I2C_Master_Transmit      bme68x_driver.c:0
         U memset       bme68x_driver.c:0
```